### PR TITLE
PEDGE-131: Add default implementation classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -436,6 +436,41 @@
         "arrify": "^1.0.1"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
+      "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
+      "integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/samsam": "2.1.0"
+      },
+      "dependencies": {
+        "@sinonjs/samsam": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
+          "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+          "dev": true,
+          "requires": {
+            "array-from": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.2.tgz",
+      "integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -447,6 +482,21 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.7.tgz",
       "integrity": "sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg==",
       "dev": true
+    },
+    "@types/sinon": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-5.0.5.tgz",
+      "integrity": "sha512-Wnuv66VhvAD2LEJfZkq8jowXGxe+gjVibeLCYcVBp7QLdw0BFx2sRkKzoiiDkYEPGg5VyqO805Rcj0stVjQwCQ==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
+      "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "abstract-leveldown": {
       "version": "0.12.4",
@@ -472,12 +522,20 @@
       "dev": true
     },
     "acorn-jsx": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
-      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
+      "version": "3.0.1",
+      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.3"
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
       }
     },
     "ajv": {
@@ -868,6 +926,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-union": {
@@ -1541,9 +1605,9 @@
       }
     },
     "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
     "chokidar": {
@@ -1972,14 +2036,12 @@
       }
     },
     "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
+        "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
@@ -2299,55 +2361,90 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.7.0.tgz",
-      "integrity": "sha512-zYCeFQahsxffGl87U2aJ7DPyH8CbWgxBC213Y8+TCanhUTf2gEvfq3EKpHmEcozTLyPmGe9LZdMAwC/CpJBM5A==",
+      "version": "4.19.1",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.5.3",
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
         "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^4.0.1",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
         "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
+        "eslint-scope": "^3.7.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
-        "esquery": "^1.0.1",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^2.0.0",
         "functional-red-black-tree": "^1.0.1",
         "glob": "^7.1.2",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.6",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.1.0",
-        "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.12.0",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.5",
-        "minimatch": "^3.0.4",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
         "path-is-inside": "^1.0.2",
         "pluralize": "^7.0.0",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
+        "regexpp": "^1.0.1",
         "require-uncached": "^1.0.3",
-        "semver": "^5.5.1",
+        "semver": "^5.3.0",
         "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^5.0.2",
-        "text-table": "^0.2.0"
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        }
       }
     },
     "eslint-config-google": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.11.0.tgz",
-      "integrity": "sha512-z541Fs5TFaY7/35v/z100InQ2f3V2J7e3u/0yKrnImgsHjh6JWgSRngfC/mZepn/+XN16jUydt64k//kxXc1fw==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.9.1.tgz",
+      "integrity": "sha512-5A83D+lH0PA81QMESKbLJd/a3ic8tPZtwUmqNrxMRo54nfFaUvtt89q/+icQ+fd66c2xQHn0KyFkzJDoAUfpZA==",
       "dev": true
     },
     "eslint-plugin-typescript": {
@@ -2360,20 +2457,14 @@
       }
     },
     "eslint-scope": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
       }
-    },
-    "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -2400,13 +2491,13 @@
       }
     },
     "espree": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
-      "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "^5.6.0",
-        "acorn-jsx": "^4.1.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -2538,13 +2629,13 @@
       }
     },
     "external-editor": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "version": "2.2.0",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
         "tmp": "^0.0.33"
       }
     },
@@ -3496,9 +3587,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "ignore-by-default": {
@@ -3564,21 +3655,22 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-      "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.0",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^3.0.0",
+        "external-editor": "^2.0.4",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rxjs": "^6.1.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
         "string-width": "^2.1.0",
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
@@ -4004,6 +4096,12 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "just-extend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
+      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4325,6 +4423,12 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.islength": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
@@ -4351,6 +4455,12 @@
       "requires": {
         "chalk": "^2.0.1"
       }
+    },
+    "lolex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+      "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -4608,6 +4718,15 @@
         "minimist": "0.0.8"
       }
     },
+    "mock-socket": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-8.0.4.tgz",
+      "integrity": "sha512-xuO+Ep0xI60sXfBwIXezHuBnSj3Rafh6TSeTH81k2aFuNf64JW46PeDaViWMXQ/nMInknUzfMriPkoVhmh5Aag==",
+      "dev": true,
+      "requires": {
+        "url-parse": "^1.2.0"
+      }
+    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -4684,11 +4803,26 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+    "nise": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
+      "integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "3.0.0",
+        "just-extend": "^3.0.0",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        }
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -6172,6 +6306,23 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -6389,6 +6540,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "querystringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
+      "dev": true
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -6888,9 +7045,9 @@
       }
     },
     "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
     },
     "regexpu-core": {
@@ -6988,6 +7145,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
       "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "resolve": {
@@ -7285,6 +7448,23 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.0.0.tgz",
+      "integrity": "sha512-8OrSYFPZ9xaECfi1ayVMd0ihYCW2OZYgX3rBczrB990gHZMM+aftvhNTJazGz/luS0Us9NWgD5P3KGQ7kYZvGg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/formatio": "^3.0.0",
+        "@sinonjs/samsam": "^2.1.2",
+        "diff": "^3.5.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^3.0.0",
+        "nise": "^1.4.5",
+        "supports-color": "^5.5.0",
+        "type-detect": "^4.0.8"
+      }
     },
     "slash": {
       "version": "2.0.0",
@@ -7649,15 +7829,43 @@
       "dev": true
     },
     "table": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.1.0.tgz",
-      "integrity": "sha512-e542in22ZLhD/fOIuXs/8yDZ9W61ltF8daM88rkRNtgTIct+vI2fTnAyu/Db2TCfEcI8i7mjZz6meLq0nW7TYg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.3",
-        "lodash": "^4.17.10",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        }
       }
     },
     "term-size": {
@@ -7687,6 +7895,12 @@
           "dev": true
         }
       }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",
@@ -7819,6 +8033,12 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -7832,219 +8052,15 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.3.tgz",
-      "integrity": "sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
       "dev": true
     },
     "typescript-eslint-parser": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-20.0.0.tgz",
-      "integrity": "sha512-HZEoGA+LnS3etUlVAPX6I8sZ7872Yb0vPvQv6QDCIE44KD3bFmvPEQ4LbiD+qGkcxh6segjVK0v3rxpb2R6oSA==",
-      "dev": true,
-      "requires": {
-        "eslint": "4.19.1",
-        "typescript-estree": "2.1.0"
-      },
-      "dependencies": {
-        "acorn-jsx": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-          "dev": true,
-          "requires": {
-            "acorn": "^3.0.4"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "3.3.0",
-              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-              "dev": true
-            }
-          }
-        },
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "chardet": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "eslint": {
-          "version": "4.19.1",
-          "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-          "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^5.3.0",
-            "babel-code-frame": "^6.22.0",
-            "chalk": "^2.1.0",
-            "concat-stream": "^1.6.0",
-            "cross-spawn": "^5.1.0",
-            "debug": "^3.1.0",
-            "doctrine": "^2.1.0",
-            "eslint-scope": "^3.7.1",
-            "eslint-visitor-keys": "^1.0.0",
-            "espree": "^3.5.4",
-            "esquery": "^1.0.0",
-            "esutils": "^2.0.2",
-            "file-entry-cache": "^2.0.0",
-            "functional-red-black-tree": "^1.0.1",
-            "glob": "^7.1.2",
-            "globals": "^11.0.1",
-            "ignore": "^3.3.3",
-            "imurmurhash": "^0.1.4",
-            "inquirer": "^3.0.6",
-            "is-resolvable": "^1.0.0",
-            "js-yaml": "^3.9.1",
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.3.0",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.2",
-            "mkdirp": "^0.5.1",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.8.2",
-            "path-is-inside": "^1.0.2",
-            "pluralize": "^7.0.0",
-            "progress": "^2.0.0",
-            "regexpp": "^1.0.1",
-            "require-uncached": "^1.0.3",
-            "semver": "^5.3.0",
-            "strip-ansi": "^4.0.0",
-            "strip-json-comments": "~2.0.1",
-            "table": "4.0.2",
-            "text-table": "~0.2.0"
-          }
-        },
-        "eslint-scope": {
-          "version": "3.7.3",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "espree": {
-          "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-          "dev": true,
-          "requires": {
-            "acorn": "^5.5.0",
-            "acorn-jsx": "^3.0.0"
-          }
-        },
-        "external-editor": {
-          "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.4.0",
-            "iconv-lite": "^0.4.17",
-            "tmp": "^0.0.33"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-          "dev": true
-        },
-        "ignore": {
-          "version": "3.3.10",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.0.4",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rx-lite": "^4.0.8",
-            "rx-lite-aggregates": "^4.0.8",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        },
-        "regexpp": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-          "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
-          "dev": true
-        },
-        "table": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-          "dev": true,
-          "requires": {
-            "ajv": "^5.2.3",
-            "ajv-keywords": "^2.1.0",
-            "chalk": "^2.1.0",
-            "lodash": "^4.17.4",
-            "slice-ansi": "1.0.0",
-            "string-width": "^2.1.1"
-          }
-        }
-      }
-    },
-    "typescript-estree": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typescript-estree/-/typescript-estree-2.1.0.tgz",
-      "integrity": "sha512-t4o+7pB4OnxV36Bp41Vgtq8vXIvIUbx1vM98PSE2mL5QBY6woFaBN9hhD8pZHIrAu24IB5gzxbkEJOXj4lWNXQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-16.0.1.tgz",
+      "integrity": "sha512-IKawLTu4A2xN3aN/cPLxvZ0bhxZHILGDKTZWvWNJ3sLNhJ3PjfMEDQmR2VMpdRPrmWOadgWXRwjLBzSA8AGsaQ==",
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.1",
@@ -8244,6 +8260,16 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "url-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -8264,6 +8290,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",
@@ -36,13 +36,17 @@
   "homepage": "https://github.com/advertima/io#readme",
   "dependencies": {
     "ajv": "^6.5.4",
-    "rxjs": "^6.3.3"
+    "rxjs": "^6.3.3",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "@types/sinon": "^5.0.5",
+    "@types/uuid": "^3.4.4",
     "ava": "^1.0.0-beta.8",
-    "eslint": "^5.7.0",
-    "eslint-config-google": "^0.11.0",
+    "eslint": "^4.18.2",
+    "eslint-config-google": "^0.9.1",
     "eslint-plugin-typescript": "^0.12.0",
+    "mock-socket": "^8.0.2",
     "nyc": "^13.1.0",
     "prettier": "^1.14.3",
     "rollup": "^0.66.6",
@@ -52,9 +56,10 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^3.0.0",
     "rollup-plugin-typescript2": "^0.17.1",
+    "sinon": "^7.0.0",
     "ts-node": "^7.0.1",
-    "typescript": "^3.1.3",
-    "typescript-eslint-parser": "^20.0.0"
+    "typescript": "^2.9.2",
+    "typescript-eslint-parser": "^16.0.0"
   },
   "ava": {
     "compileEnhancements": false,

--- a/src/connection/StreamMock.ts
+++ b/src/connection/StreamMock.ts
@@ -1,0 +1,70 @@
+/* eslint-disable require-jsdoc */
+class StreamBaseMock {
+  ws;
+  onopen;
+  onmessage;
+  onclose;
+
+  constructor(port, hosts = ['localhost']) {
+    const uri = `ws://${hosts[0]}:${port}`;
+    this.ws = new WebSocket(uri);
+    this.ws.onopen = this._onopen.bind(this);
+    this.ws.onmessage = this._onmessage.bind(this);
+    this.ws.onclose = this._onclose.bind(this);
+  }
+
+  close() {
+    this.ws.close();
+  }
+
+  sendJson(msg) {
+    this.ws.send(JSON.stringify(msg));
+  }
+
+  _onopen(e) {
+    if (this.onopen) {
+      this.onopen(e);
+    }
+  }
+
+  _onclose(event) {
+    if (this.onclose) {
+      this.onclose(event);
+    }
+  }
+
+  _onmessage(event) {
+    if (this.onmessage !== undefined) {
+      this.onmessage(event);
+    }
+  }
+}
+/* eslint-enable require-jsdoc */
+
+/**
+ * This class mocks the JsonStream class from @advertima/js-libs
+ */
+export class JsonStreamMock extends StreamBaseMock {
+  /**
+   * Creates an instance of JsonStream
+   * @param {number} port
+   * @param {string[]} hosts
+   */
+  constructor(port: number = 8001, hosts: string[]) {
+    super(port, hosts);
+  }
+}
+
+/**
+ * This class mocks the BinaryStream class from @advertima/js-libs
+ */
+export class BinaryStreamMock extends StreamBaseMock {
+  /**
+   * Creates an instance of BinaryStream
+   * @param {number} port
+   * @param {string[]} hosts
+   */
+  constructor(port: number = 8002, hosts: string[]) {
+    super(port, hosts);
+  }
+}

--- a/src/connection/TecWSConnection.spec.ts
+++ b/src/connection/TecWSConnection.spec.ts
@@ -1,0 +1,136 @@
+import test from 'ava';
+import { Server } from 'mock-socket';
+import { TecWSConnection } from './TecWSConnection';
+import { WSConnectionStatus } from './WSConnection';
+
+test.serial.cb(
+  'should connect to the websockets, update the status and close the connection',
+  t => {
+    const fakeJsonURL = 'ws://0.0.1.0:8181';
+    const mockJsonServer = new Server(fakeJsonURL);
+
+    const fakeBinaryURL = 'ws://127.0.12.14:8080';
+    const mockBinaryServer = new Server(fakeBinaryURL);
+
+    const c = new TecWSConnection();
+    t.is(c['jsonStreamStatus'], WSConnectionStatus.Closed);
+    t.is(c['binaryStreamStatus'], WSConnectionStatus.Closed);
+
+    c.open({
+      jsonHost: '0.0.1.0',
+      jsonPort: 8181,
+      binaryHost: '127.0.12.14',
+      binaryPort: 8080,
+    });
+    setTimeout(() => {
+      t.is(c['jsonStreamStatus'], WSConnectionStatus.Open);
+      t.is(c['binaryStreamStatus'], WSConnectionStatus.Open);
+
+      c.close();
+
+      setTimeout(() => {
+        t.is(c['jsonStreamStatus'], WSConnectionStatus.Closed);
+        t.is(c['binaryStreamStatus'], WSConnectionStatus.Closed);
+
+        mockJsonServer.stop(null);
+        mockBinaryServer.stop(null);
+        t.end();
+      }, 100);
+    }, 100);
+  }
+);
+
+test.serial.cb('should receive a message from the json stream and emit it to the Subject', t => {
+  const fakeJsonURL = 'ws://localhost:8001';
+  const mockJsonServer = new Server(fakeJsonURL);
+
+  const fakeBinaryURL = 'ws://localhost:8002';
+  const mockBinaryServer = new Server(fakeBinaryURL);
+
+  const c = new TecWSConnection();
+  c.open();
+
+  const subscription = c.jsonStreamMessages.subscribe(e => {
+    t.is(e.data, 'test message from mock json server');
+    subscription.unsubscribe();
+
+    c.close();
+    mockJsonServer.stop(null);
+    mockBinaryServer.stop(null);
+    t.end();
+  });
+
+  mockJsonServer.on('connection', socket => {
+    socket.send('test message from mock json server');
+  });
+});
+
+test.serial.cb('should send a message to the binary stream', t => {
+  const fakeJsonURL = 'ws://localhost:8001';
+  const mockJsonServer = new Server(fakeJsonURL);
+
+  const fakeBinaryURL = 'ws://localhost:8002';
+  const mockBinaryServer = new Server(fakeBinaryURL);
+
+  const c = new TecWSConnection();
+
+  mockBinaryServer.on('connection', socket => {
+    socket['on']('message', (e: any) => {
+      t.deepEqual(
+        e,
+        JSON.stringify({
+          name: 'client1',
+          id: 1234,
+        })
+      );
+
+      c.close();
+      mockBinaryServer.stop(null);
+      mockJsonServer.stop(null);
+      t.end();
+    });
+  });
+
+  c.open();
+
+  setTimeout(() => {
+    c.sendBinaryStream({
+      name: 'client1',
+      id: 1234,
+    });
+  }, 100);
+});
+
+test.serial.cb('should send a message to the json stream', t => {
+  const fakeJsonURL = 'ws://localhost:8001';
+  const mockJsonServer = new Server(fakeJsonURL);
+
+  const fakeBinaryURL = 'ws://localhost:8002';
+  const mockBinaryServer = new Server(fakeBinaryURL);
+
+  const c = new TecWSConnection();
+
+  mockJsonServer.on('connection', socket => {
+    socket['on']('message', (e: any) => {
+      t.deepEqual(
+        e,
+        JSON.stringify({
+          value: 'hello',
+        })
+      );
+
+      c.close();
+      mockBinaryServer.stop(null);
+      mockJsonServer.stop(null);
+      t.end();
+    });
+  });
+
+  c.open();
+
+  setTimeout(() => {
+    c.sendJsonStream({
+      value: 'hello',
+    });
+  }, 100);
+});

--- a/src/connection/TecWSConnection.ts
+++ b/src/connection/TecWSConnection.ts
@@ -1,0 +1,174 @@
+let JsonStream;
+let BinaryStream;
+
+declare type JsonStream = typeof JsonStream;
+declare type BinaryStream = typeof BinaryStream;
+
+if (process.env.NODE_ENV === 'test') {
+  JsonStream = require('./StreamMock').JsonStreamMock;
+  BinaryStream = require('./StreamMock').BinaryStreamMock;
+} else {
+  JsonStream = require('@advertima/js-libs').JsonStream;
+  BinaryStream = require('@advertima/js-libs').BinaryStream;
+}
+
+import { Observable, Subject } from 'rxjs';
+import { WSConnection, WSConnectionStatus } from './WSConnection';
+
+export interface TecSdkWSConnectionOptions {
+  jsonPort?: number; // port for the json stream connection
+  jsonHost?: string; // host for the json stream connection
+  binaryPort?: number; // port for the binary stream connection
+  binaryHost?: string; // host for the json stream connection
+}
+
+/**
+ * Connection to the TEC SDK websocket
+ */
+export class TecWSConnection implements WSConnection {
+  private jsonStreamStatus = WSConnectionStatus.Closed;
+  private jsonStream: JsonStream;
+  private jsonStreamMessagesSubject: Subject<MessageEvent> = new Subject<MessageEvent>();
+
+  private binaryStreamStatus = WSConnectionStatus.Closed;
+  private binaryStream: BinaryStream;
+  private binaryStreamMessagesSubject: Subject<any> = new Subject<any>();
+
+  /**
+   * Json stream messages wrapped in an Observable
+   * @return {Observable<any>}
+   */
+  get jsonStreamMessages(): Observable<MessageEvent> {
+    return this.jsonStreamMessagesSubject.asObservable();
+  }
+
+  /**
+   * Binary stream messages wrapped in an Observable
+   * @return {Observable<any>}
+   */
+  get binaryStreamMessages(): Observable<any> {
+    return this.binaryStreamMessagesSubject.asObservable();
+  }
+
+  /**
+   * Opens the connection to the Json and Binary streams
+   * @param {TecSdkWSConnectionOptions} options
+   */
+  public open(options: TecSdkWSConnectionOptions = {}): void {
+    if (this.jsonStreamStatus === WSConnectionStatus.Closed) {
+      this.openJsonStream(options.jsonPort, options.jsonHost);
+    }
+
+    if (this.binaryStreamStatus === WSConnectionStatus.Closed) {
+      this.openBinaryStream(options.binaryPort, options.binaryHost);
+    }
+  }
+
+  /**
+   * Closes the connection to the Json and Binary streams
+   */
+  public close(): void {
+    if (this.jsonStreamStatus !== WSConnectionStatus.Closed) {
+      this.jsonStream.close();
+      this.jsonStreamMessagesSubject.complete();
+    }
+    if (this.binaryStreamStatus !== WSConnectionStatus.Closed) {
+      this.binaryStream.close();
+      this.binaryStreamMessagesSubject.complete();
+    }
+  }
+
+  /**
+   * Sends data to the Json stream
+   * @param {any} data to send
+   */
+  public sendJsonStream(data: any): void {
+    if (this.jsonStreamStatus !== WSConnectionStatus.Closed) {
+      this.jsonStream.sendJson(data);
+    }
+  }
+
+  /**
+   * Sends data to the Binary stream
+   * @param {any} data to send
+   */
+  public sendBinaryStream(data: any): void {
+    if (this.binaryStreamStatus !== WSConnectionStatus.Closed) {
+      this.binaryStream.sendJson(data);
+    }
+  }
+
+  /**
+   * Opens the connection to the Json stream
+   * @param {number} port
+   * @param {string} host
+   */
+  private openJsonStream(port?: number, host?: string): void {
+    this.jsonStream = new JsonStream(port, host ? [host] : undefined);
+    this.jsonStreamStatus = WSConnectionStatus.Connecting;
+    this.jsonStream.onopen = this.onJsonStreamOpen.bind(this);
+    this.jsonStream.onclose = this.onJsonStreamClose.bind(this);
+    this.jsonStream.onmessage = this.onJsonStreamMessage.bind(this);
+  }
+
+  /**
+   * Opens the connection to the Binary stream
+   * @param {number} port
+   * @param {string} host
+   */
+  private openBinaryStream(port?: number, host?: string): void {
+    this.binaryStream = new BinaryStream(port, host ? [host] : undefined);
+    this.binaryStreamStatus = WSConnectionStatus.Connecting;
+    this.binaryStream.onopen = this.onBinaryStreamOpen.bind(this);
+    this.binaryStream.onclose = this.onBinaryStreamClose.bind(this);
+    this.binaryStream.onimage = this.onBinaryStreamMessage.bind(this);
+    this.binaryStream.onskeleton = this.onBinaryStreamMessage.bind(this);
+    this.binaryStream.onthumbnail = this.onBinaryStreamMessage.bind(this);
+    this.binaryStream.onheatmap = this.onBinaryStreamMessage.bind(this);
+    this.binaryStream.ondepthmap = this.onBinaryStreamMessage.bind(this);
+  }
+
+  /**
+   * Gets called when the JsonStream instance is opened.
+   */
+  private onJsonStreamOpen(): void {
+    this.jsonStreamStatus = WSConnectionStatus.Open;
+  }
+
+  /**
+   * Gets called when the JsonStream instance is opened.
+   */
+  private onJsonStreamClose(): void {
+    this.jsonStreamStatus = WSConnectionStatus.Closed;
+  }
+
+  /**
+   * Emits a message to the JsonStream subject
+   * @param {MessageEvent} e message
+   */
+  private onJsonStreamMessage(e: MessageEvent): void {
+    this.jsonStreamMessagesSubject.next(e);
+  }
+
+  /**
+   * Gets called when the BinaryStream instance is opened.
+   */
+  private onBinaryStreamOpen(): void {
+    this.binaryStreamStatus = WSConnectionStatus.Open;
+  }
+
+  /**
+   * Gets called when the BinaryStream instance is opened.
+   */
+  private onBinaryStreamClose(): void {
+    this.binaryStreamStatus = WSConnectionStatus.Closed;
+  }
+
+  /**
+   * Emits a message to the BinaryStream subject
+   * @param {any} e message
+   */
+  private onBinaryStreamMessage(e: any): void {
+    this.binaryStreamMessagesSubject.next(e);
+  }
+}

--- a/src/connection/WSConnection.ts
+++ b/src/connection/WSConnection.ts
@@ -1,3 +1,7 @@
+import { Observable } from 'rxjs';
+
+export const WSConnectionType = Symbol.for('WSConnectionType');
+
 export enum WSConnectionStatus {
   Open = 'open',
   Closed = 'closed',
@@ -8,6 +12,10 @@ export enum WSConnectionStatus {
  * WebSocket connection
  */
 export interface WSConnection {
-  open(): void;
+  open(args): void;
   close(): void;
+  sendJsonStream(data: any): void;
+  sendBinaryStream(data: any): void;
+  readonly jsonStreamMessages: Observable<MessageEvent>;
+  readonly binaryStreamMessages: Observable<any>;
 }

--- a/src/event/EventMonitor.ts
+++ b/src/event/EventMonitor.ts
@@ -50,10 +50,10 @@ export class EventMonitor {
 
     // Attach the list of persons ids from the PoIMonitor
     const personList = Array.from(
-        this.poiMonitor
-            .getSnapshot()
-            .getPersons()
-            .values()
+      this.poiMonitor
+        .getSnapshot()
+        .getPersons()
+        .values()
     );
     event.persons = personList.map((p: PersonDetection) => p.personPutId);
 

--- a/src/incoming-message/TecSDKService.spec.ts
+++ b/src/incoming-message/TecSDKService.spec.ts
@@ -1,0 +1,51 @@
+import test from 'ava';
+import { Subject } from 'rxjs';
+import { stub } from 'sinon';
+import { TecSDKService } from './TecSDKService';
+
+/* eslint-disable require-jsdoc */
+class MockTecSdkWsConnection {
+  jsonStreamMessages = null;
+  open() {}
+}
+/* eslint-enable require-jsdoc */
+
+test.cb('should get a parsed object when a json message arrives', t => {
+  const connection = new MockTecSdkWsConnection();
+  const service = new TecSDKService(connection as any);
+
+  const subject = new Subject();
+  stub(connection, 'jsonStreamMessages').value(subject.asObservable());
+
+  const expected = {
+    name: 'I expect this object',
+  };
+
+  service.jsonStreamMessages().subscribe(msg => {
+    t.deepEqual(msg, expected);
+    t.end();
+  });
+
+  subject.next({
+    data: expected,
+  });
+});
+
+test.cb('should get the raw data if it cannot be parsed', t => {
+  const connection = new MockTecSdkWsConnection();
+  const service = new TecSDKService(connection as any);
+
+  const subject = new Subject();
+  stub(connection, 'jsonStreamMessages').value(subject.asObservable());
+
+  const expected = 42;
+
+  service.jsonStreamMessages().subscribe(msg => {
+    t.deepEqual(msg, expected);
+    t.end();
+  });
+
+  subject.next({
+    data: expected,
+  });
+});

--- a/src/incoming-message/TecSDKService.ts
+++ b/src/incoming-message/TecSDKService.ts
@@ -1,0 +1,39 @@
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { IncomingMessageService } from './IncomingMessageService';
+import { WSConnection } from '../connection/WSConnection';
+
+/**
+ * The TecSDK Service can be used to get the messages coming from the Tec SDK
+ */
+export class TecSDKService implements IncomingMessageService {
+  /**
+   * Creates an instance of the TecSDKService by providing a connection
+   */
+  constructor(private connection: WSConnection) {}
+
+  /**
+   * Try to parse them the messages from the connection and forward them
+   * @return {Observable<any>}
+   */
+  public jsonStreamMessages(): Observable<any> {
+    return this.connection.jsonStreamMessages.pipe(
+      map((event: MessageEvent) => {
+        const data = event.data;
+        let json = data;
+        try {
+          json = JSON.parse(data);
+        } catch (e) {}
+        return json;
+      })
+    );
+  }
+
+  /**
+   * Binary stream messages wrapped in an Observable
+   * @return {Observable<any>}
+   */
+  public binaryStreamMessages(): Observable<any> {
+    return this.connection.binaryStreamMessages;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,5 +15,8 @@ export * from './event/ContentEvent';
 export * from './event/EventMonitor';
 export * from './constants/Constants';
 export * from './connection/WSConnection';
+export * from './connection/TecWSConnection';
 export * from './rpc/RPCService';
+export * from './rpc/TecRPCService';
 export * from './incoming-message/IncomingMessageService';
+export * from './incoming-message/TecSDKService';

--- a/src/messages/content/ContentSchema.ts
+++ b/src/messages/content/ContentSchema.ts
@@ -10,9 +10,7 @@ export const ContentSchema = {
     record_type: {
       type: 'string',
       description: 'Identifier the type of the record. Never changes for one specific record type.',
-      enum: [
-        'content_event',
-      ],
+      enum: ['content_event'],
     },
     poi: {
       type: 'integer',
@@ -36,12 +34,5 @@ export const ContentSchema = {
       },
     },
   },
-  required: [
-    'record_type',
-    'poi',
-    'local_timestamp',
-    'name',
-    'content_id',
-    'person_put_ids',
-  ],
+  required: ['record_type', 'poi', 'local_timestamp', 'name', 'content_id', 'person_put_ids'],
 };

--- a/src/poi/POIMonitor.ts
+++ b/src/poi/POIMonitor.ts
@@ -1,5 +1,5 @@
 import { BehaviorSubject } from 'rxjs';
-import { Observer } from 'rxjs';
+import { Observer, Observable } from 'rxjs';
 import { Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Message } from '../messages/Message';
@@ -25,8 +25,7 @@ export class POIMonitor {
    *
    * Subscribes to the TecSDKService json stream to listen for events reported
    * by the POI.
-   * @param {TecSDKService} tecSDKService
-   * @param {MessageFactory} messageFactory
+   * @param {IncomingMessageService} msgService
    */
   constructor(private msgService: IncomingMessageService) {}
 
@@ -36,9 +35,9 @@ export class POIMonitor {
   public start(): void {
     if (!this.jsonStreamSubscription || this.jsonStreamSubscription.closed) {
       this.jsonStreamSubscription = this.msgService
-          .jsonStreamMessages()
-          .pipe(map(json => MessageFactory.parse(json)))
-          .subscribe(new MessageObserver(this));
+        .jsonStreamMessages()
+        .pipe(map(json => MessageFactory.parse(json)))
+        .subscribe(new MessageObserver(this));
     }
   }
 
@@ -95,15 +94,11 @@ export class POIMonitor {
   }
 
   /**
-   * Adds an observer to the list of observers that will be notified
-   * when the POISnapshot is updated.
-   *
-   * @param {Observer<POISnapshot>} observer the observer that will be notified.
-   * @return {Subscription} the subscription object,
-   * so consumers can unsubscribe.
+   * Returns an Observable emitting the POISnapshot updates
+   * @return {Observable<POISnapshot>}
    */
-  public subscribe(observer: Observer<POISnapshot>): Subscription {
-    return this.snapshots.subscribe(observer);
+  public getSnapshots(): Observable<POISnapshot> {
+    return this.snapshots.asObservable();
   }
 }
 

--- a/src/rpc/TecRPCService.spec.ts
+++ b/src/rpc/TecRPCService.spec.ts
@@ -1,0 +1,36 @@
+import test from 'ava';
+import { stub } from 'sinon';
+import { Subject } from 'rxjs';
+import { TecRPCService } from './TecRPCService';
+
+/* eslint-disable require-jsdoc */
+class MockTecSdkWsConnection {
+  jsonStreamMessages = null;
+  open() {}
+  sendJsonStream() {}
+}
+/* eslint-enable require-jsdoc */
+
+test.cb('should send a rpc, subscribe and receive the response', t => {
+  const connection = new MockTecSdkWsConnection();
+  const service = new TecRPCService(connection as any);
+
+  // Mock the message observables
+  const subject = new Subject();
+  stub(connection, 'jsonStreamMessages').value(subject.asObservable());
+  stub(connection, 'sendJsonStream').callsFake(json => {
+    setTimeout(() => {
+      subject.next({
+        message_id: json.message_id,
+        data: {
+          title: 'world',
+        },
+      });
+    });
+  });
+
+  service.rpc('test', { title: 'hello' }).subscribe(msg => {
+    t.is(msg.data.title, 'world');
+    t.end();
+  });
+});

--- a/src/rpc/TecRPCService.ts
+++ b/src/rpc/TecRPCService.ts
@@ -1,0 +1,33 @@
+import { v4 } from 'uuid';
+import { Observable } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { RPCService } from './RPCService';
+import { WSConnection } from '../connection/WSConnection';
+
+/**
+ * This service wraps the Tec RPC logic
+ */
+export class TecRPCService implements RPCService {
+  /**
+   * Creates an instance of the TecRPCService by providing a connection
+   */
+  constructor(private connection: WSConnection) {}
+
+  /**
+   * Sends an RPC through the Tec SDK connection
+   * @param {string} methodName name of the RPC method
+   * @param {Object} data       data to send
+   * @return {Observable<any>}  Observable of the RPC response
+   */
+  public rpc(methodName: string, data: any): Observable<any> {
+    const messageId = v4();
+    const json = {
+      type: 'rpc',
+      message_id: messageId,
+      method_name: methodName,
+      data,
+    };
+    this.connection.sendJsonStream(json);
+    return this.connection.jsonStreamMessages.pipe(filter(msg => msg['message_id'] === messageId));
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,12 @@
     "declaration": true,
     "lib": ["es2017", "dom"],
     "module": "esnext",
-    "outDir": "dist",
     "sourceMap": true,
-    "target": "es6"
+    "target": "es6",
+    "types": ["node", "uuid", "sinon"]
   },
   "exclude": [
     "dist",
-    "**/*.spec.ts",
     "node_modules"
   ]
 }


### PR DESCRIPTION
This PR adds the implementation classes that used to be in our bitbucket repo `product-engine`. For the moment, I just moved the classes here, and export them. 

**The next step will be to design the external API of this library** so that the user can import only one class or function as this example https://confluence.advertima.com/pages/viewpage.action?pageId=23036911. (Right now, the user needs to import multiple services and connect them together, so it's quite low level and we want to get rid of that).