### PR TITLE
Stub console.warn during unit tests

### DIFF
--- a/src/messages/MessageFactory.spec.ts
+++ b/src/messages/MessageFactory.spec.ts
@@ -1,4 +1,5 @@
 import test from 'ava';
+import { stub } from 'sinon';
 import { MessageFactory } from './MessageFactory';
 import { PersonDetectionMessage } from './person-detection/PersonDetectionMessage';
 import { PersonsAliveMessage } from './persons-alive/PersonsAliveMessage';
@@ -176,6 +177,12 @@ const contentMessage = {
   },
 };
 
+let consoleWarnSpy;
+
+test.before(() => {
+  consoleWarnSpy = stub(console, 'warn').returns(null);
+});
+
 test('should parse a person_update message', t => {
   const msg = MessageFactory.parse(personDetectionMessage);
   t.is(msg instanceof PersonDetectionMessage, true);
@@ -223,6 +230,9 @@ test('should parse an invalid person_update message', t => {
 
 test('should parse a content message', t => {
   const msg = MessageFactory.parse(contentMessage);
-  console.log(contentMessage['data']['record_type']);
   t.is(msg instanceof ContentMessage, true);
+});
+
+test.after(() => {
+  consoleWarnSpy.restore();
 });


### PR DESCRIPTION
In `MessageFactory.ts` [we log](https://github.com/advertima/io/blob/development/src/messages/MessageFactory.ts#L32) the parsing error. These errors could be confusing in the unit tests logs.