### PR TITLE
Fix typo in poiMonitor.start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -40,7 +40,7 @@ export class IO {
    */
   public connect(options: IOOptions): void {
     this.connection.open(options);
-    this.poiMonitor.start;
+    this.poiMonitor.start();
   }
 
   /**


### PR DESCRIPTION
`start` instead of `start()`....
Consequently the poi monitoring never started.