### PR TITLE
Fix/emit value when io connection opened

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -508,7 +508,7 @@
     },
     "abstract-leveldown": {
       "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+      "resolved": "http://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
       "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
       "dev": true,
       "requires": {
@@ -2437,7 +2437,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
@@ -2500,7 +2500,7 @@
     },
     "espree": {
       "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
@@ -7363,7 +7363,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -7792,7 +7792,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -7864,7 +7864,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/connection/TecWSConnection.ts
+++ b/src/connection/TecWSConnection.ts
@@ -70,9 +70,7 @@ export class TecWSConnection implements WSConnection {
    * @param {any} data to send
    */
   public sendJsonStream(data: any): void {
-    if (this.jsonStreamStatus !== WSConnectionStatus.Closed) {
-      this.jsonStream.sendJson(data);
-    }
+    this.jsonStream.sendJson(data);
   }
 
   /**
@@ -80,9 +78,7 @@ export class TecWSConnection implements WSConnection {
    * @param {any} data to send
    */
   public sendBinaryStream(data: any): void {
-    if (this.binaryStreamStatus !== WSConnectionStatus.Closed) {
-      this.binaryStream.sendJson(data);
-    }
+    this.binaryStream.sendJson(data);
   }
 
   /**

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -30,7 +30,7 @@ export class IO {
    */
   constructor(private connection: WSConnection = new TecWSConnection()) {
     this.incomingMessageService = new TecSDKService(this.connection);
-    this.rpcService = new TecRPCService(this.connection);
+    this.rpcService = new TecRPCService(this.connection, this.incomingMessageService);
     this.poiMonitor = new POIMonitor(this.incomingMessageService);
   }
 

--- a/src/rpc/TecRPCService.spec.ts
+++ b/src/rpc/TecRPCService.spec.ts
@@ -5,19 +5,23 @@ import { TecRPCService } from './TecRPCService';
 
 /* eslint-disable require-jsdoc */
 class MockTecSdkWsConnection {
-  jsonStreamMessages = null;
   open() {}
   sendJsonStream() {}
+}
+
+class MockTecSdkService {
+  jsonStreamMessages() {}
 }
 /* eslint-enable require-jsdoc */
 
 test.cb('should send a rpc, subscribe and receive the response', t => {
   const connection = new MockTecSdkWsConnection();
-  const service = new TecRPCService(connection as any);
+  const msgService = new MockTecSdkService();
+  const service = new TecRPCService(connection as any, msgService as any);
 
   // Mock the message observables
   const subject = new Subject();
-  stub(connection, 'jsonStreamMessages').value(subject.asObservable());
+  stub(msgService, 'jsonStreamMessages').returns(subject.asObservable());
   stub(connection, 'sendJsonStream').callsFake(json => {
     setTimeout(() => {
       subject.next({
@@ -30,7 +34,7 @@ test.cb('should send a rpc, subscribe and receive the response', t => {
   });
 
   service.rpc('test', { title: 'hello' }).subscribe(msg => {
-    t.is(msg.data.title, 'world');
+    t.is(msg.title, 'world');
     t.end();
   });
 });

--- a/src/rpc/TecRPCService.ts
+++ b/src/rpc/TecRPCService.ts
@@ -1,8 +1,9 @@
 import { v4 } from 'uuid';
 import { Observable } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 import { RPCService } from './RPCService';
 import { WSConnection } from '../connection/WSConnection';
+import { IncomingMessageService } from '../incoming-message/IncomingMessageService';
 
 /**
  * This service wraps the Tec RPC logic
@@ -11,7 +12,7 @@ export class TecRPCService implements RPCService {
   /**
    * Creates an instance of the TecRPCService by providing a connection
    */
-  constructor(private connection: WSConnection) {}
+  constructor(private connection: WSConnection, private msgService: IncomingMessageService) {}
 
   /**
    * Sends an RPC through the Tec SDK connection
@@ -28,6 +29,9 @@ export class TecRPCService implements RPCService {
       data,
     };
     this.connection.sendJsonStream(json);
-    return this.connection.jsonStreamMessages.pipe(filter(msg => msg['message_id'] === messageId));
+    return this.msgService.jsonStreamMessages().pipe(
+      filter(msg => msg['message_id'] === messageId),
+      map(msg => msg.data)
+    );
   }
 }


### PR DESCRIPTION
This fix 2 incorrect behaviours:

1. when the connection was closed we prevented the messages to be sent. This should not be the case since the Stream implementations handle it, they buffer the messages and send them as soon as the connection is opened.
2. in the `TecRPCService`, in order to forward the rpc response to the client, I was piping the connection stream. I should use the `TecSDKService` streams since they are already parsed.