### PR TITLE
Fix/binary stream parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ io.rpc('analytics', data);
 io.rpc('download', data).subbscribe(res => ...);
 
 io.jsonStreamMessages().subscribe(msg => ...);
-io.binaryStreamMessages().subscribe(msg => ...);
+io.skeletonStreamMessages().subscribe(msg => ...);
+io.imageStreamMessages().subscribe(msg => ...);
+io.thumbnailStreamMessages().subscribe(msg => ...);
+io.heatmapStreamMessages().subscribe(msg => ...);
+io.depthmapStreamMessages().subscribe(msg => ...);
 
 io.getSnapshots().subscribe(snapshot => ...);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.3.4",
+  "version": "0.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/connection/WSConnection.ts
+++ b/src/connection/WSConnection.ts
@@ -1,4 +1,5 @@
 import { Observable } from 'rxjs';
+import { BinaryMessageEvent } from '../types';
 
 export const WSConnectionType = Symbol.for('WSConnectionType');
 
@@ -17,5 +18,5 @@ export interface WSConnection {
   sendJsonStream(data: any): void;
   sendBinaryStream(data: any): void;
   readonly jsonStreamMessages: Observable<MessageEvent>;
-  readonly binaryStreamMessages: Observable<any>;
+  readonly binaryStreamMessages: Observable<BinaryMessageEvent>;
 }

--- a/src/incoming-message/IncomingMessageService.ts
+++ b/src/incoming-message/IncomingMessageService.ts
@@ -1,8 +1,9 @@
 import { Observable } from 'rxjs';
+import { BinaryMessageEvent, BinaryType } from '../types';
 
 export const IncomingMessageServiceType = Symbol.for('IncomingMessageServiceType');
 
 export interface IncomingMessageService {
   jsonStreamMessages(): Observable<any>;
-  binaryStreamMessages(): Observable<any>;
+  binaryStreamMessages(type?: BinaryType): Observable<BinaryMessageEvent>;
 }

--- a/src/incoming-message/TecSDKService.ts
+++ b/src/incoming-message/TecSDKService.ts
@@ -1,7 +1,8 @@
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, filter } from 'rxjs/operators';
 import { IncomingMessageService } from './IncomingMessageService';
 import { WSConnection } from '../connection/WSConnection';
+import { BinaryType, BinaryMessageEvent } from '../types';
 
 /**
  * The TecSDK Service can be used to get the messages coming from the Tec SDK
@@ -30,10 +31,14 @@ export class TecSDKService implements IncomingMessageService {
   }
 
   /**
-   * Binary stream messages wrapped in an Observable
-   * @return {Observable<any>}
+   * Forwards the messages from the binary stream.
+   * If a type is provided, will filter the messages by type
+   * @param {BinaryType} type of the binary message
+   * @return {Observable<BinaryMessageEvent>}
    */
-  public binaryStreamMessages(): Observable<any> {
-    return this.connection.binaryStreamMessages;
+  public binaryStreamMessages(type?: BinaryType): Observable<BinaryMessageEvent> {
+    return this.connection.binaryStreamMessages.pipe(
+      filter((e: BinaryMessageEvent) => !type || type === e.type)
+    );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,4 @@ export * from './connection/WSConnection';
 export * from './incoming-message/IncomingMessageService';
 export * from './rpc/RPCService';
 export * from './io/IO';
+export * from './types';

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -36,11 +36,17 @@ export class IO {
   }
 
   /**
-   * [start description]
+   * Opens a connection and start monitoring the messages
    * @param {IOOptions} options [description]
    */
   public connect(options: IOOptions): void {
     this.connection.open(options);
+    this.connection.sendBinaryStream({
+      canvas: { width: 100, height: 100 },
+      image: { width: 0, height: 0 },
+      thumbnail: { width: 0, height: 0 },
+    });
+
     this.poiMonitor.start();
   }
 

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -7,7 +7,7 @@ import { TecRPCService } from '../rpc/TecRPCService';
 import { RPCService } from '../rpc/RPCService';
 import { POIMonitor } from '../poi/POIMonitor';
 import { POISnapshot } from '../poi/POISnapshot';
-import { BinaryMessageEvent } from '../types';
+import { BinaryMessageEvent, BinaryType } from '../types';
 
 export interface IOOptions {
   jsonPort?: number; // port for the json stream connection
@@ -65,7 +65,7 @@ export class IO {
    * @return {Observable<BinaryMessageEvent>}
    */
   public imageStreamMessages(): Observable<BinaryMessageEvent> {
-    return this.incomingMessageService.imageStreamMessages();
+    return this.incomingMessageService.binaryStreamMessages(BinaryType.IMAGE);
   }
 
   /**
@@ -73,7 +73,7 @@ export class IO {
    * @return {Observable<BinaryMessageEvent>}
    */
   public skeletonStreamMessages(): Observable<BinaryMessageEvent> {
-    return this.incomingMessageService.skeletonStreamMessages();
+    return this.incomingMessageService.binaryStreamMessages(BinaryType.SKELETON);
   }
 
   /**
@@ -81,7 +81,7 @@ export class IO {
    * @return {Observable<BinaryMessageEvent>}
    */
   public thumbnailStreamMessages(): Observable<BinaryMessageEvent> {
-    return this.incomingMessageService.thumbnailStreamMessages();
+    return this.incomingMessageService.binaryStreamMessages(BinaryType.THUMBNAIL);
   }
 
   /**
@@ -89,7 +89,7 @@ export class IO {
    * @return {Observable<BinaryMessageEvent>}
    */
   public heatmapStreamMessages(): Observable<BinaryMessageEvent> {
-    return this.incomingMessageService.heatmapStreamMessages();
+    return this.incomingMessageService.binaryStreamMessages(BinaryType.HEATMAP);
   }
 
   /**
@@ -97,7 +97,7 @@ export class IO {
    * @return {Observable<BinaryMessageEvent>}
    */
   public depthmapStreamMessages(): Observable<BinaryMessageEvent> {
-    return this.incomingMessageService.depthmapStreamMessages();
+    return this.incomingMessageService.binaryStreamMessages(BinaryType.DEPTHMAP);
   }
 
   /**

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -7,6 +7,7 @@ import { TecRPCService } from '../rpc/TecRPCService';
 import { RPCService } from '../rpc/RPCService';
 import { POIMonitor } from '../poi/POIMonitor';
 import { POISnapshot } from '../poi/POISnapshot';
+import { BinaryMessageEvent } from '../types';
 
 export interface IOOptions {
   jsonPort?: number; // port for the json stream connection
@@ -60,11 +61,43 @@ export class IO {
   }
 
   /**
-   * Binary stream messages
-   * @return {Observable<any>}
+   * Image binary stream messages
+   * @return {Observable<BinaryMessageEvent>}
    */
-  public binaryStreamMessages(): Observable<any> {
-    return this.incomingMessageService.binaryStreamMessages();
+  public imageStreamMessages(): Observable<BinaryMessageEvent> {
+    return this.incomingMessageService.imageStreamMessages();
+  }
+
+  /**
+   * Skeleton binary stream messages
+   * @return {Observable<BinaryMessageEvent>}
+   */
+  public skeletonStreamMessages(): Observable<BinaryMessageEvent> {
+    return this.incomingMessageService.skeletonStreamMessages();
+  }
+
+  /**
+   * Thumbnail binary stream messages
+   * @return {Observable<BinaryMessageEvent>}
+   */
+  public thumbnailStreamMessages(): Observable<BinaryMessageEvent> {
+    return this.incomingMessageService.thumbnailStreamMessages();
+  }
+
+  /**
+   * Heatmap binary stream messages
+   * @return {Observable<BinaryMessageEvent>}
+   */
+  public heatmapStreamMessages(): Observable<BinaryMessageEvent> {
+    return this.incomingMessageService.heatmapStreamMessages();
+  }
+
+  /**
+   * Depthmap binary stream messages
+   * @return {Observable<BinaryMessageEvent>}
+   */
+  public depthmapStreamMessages(): Observable<BinaryMessageEvent> {
+    return this.incomingMessageService.depthmapStreamMessages();
   }
 
   /**

--- a/src/messages/MessageFactory.spec.ts
+++ b/src/messages/MessageFactory.spec.ts
@@ -5,6 +5,8 @@ import { PersonDetectionMessage } from './person-detection/PersonDetectionMessag
 import { PersonsAliveMessage } from './persons-alive/PersonsAliveMessage';
 import { ContentMessage } from './content/ContentMessage';
 import { UnknownMessage } from './unknown/UnknownMessage';
+import { SkeletonMessage } from './skeleton/SkeletonMessage';
+import { BinaryType } from '../types';
 
 const personDetectionMessage = {
   subject: 'person_update',
@@ -177,6 +179,18 @@ const contentMessage = {
   },
 };
 
+/* eslint-disable */
+// prettier-ignore
+const skeletonData = [0,3,0,0,0,0,127,255,127,255,0,0,0,35,0,86,132,191,125,213,20,226,0,34,0,93,133,145,125,187,20,48,0,0,0,0,127,255,127,255,0,0,0,0,0,0,127,255,127,255,0,0,0,36,0,80,132,14,125,209,21,249,0,53,0,79,132,127,128,184,24,124,0,0,0,0,127,255,127,255,0,0,0,69,0,92,134,97,131,170,23,184,0,0,0,0,127,255,127,255,0,0,0,0,0,0,127,255,127,255,0,0,0,68,0,82,132,163,131,112,22,226,0,0,0,0,127,255,127,255,0,0,0,0,0,0,127,255,127,255,0,0,0,0,0,0,127,255,127,255,0,0,0,0,0,0,127,255,127,255,0,0,0,22,0,89,133,37,123,202,20,133,0,0,0,0,127,255,127,255,0,0,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,163,0,0,0,0,0,0,0,0,20,0,41,128,0,127,254,0,1,0,42,0,53,128,5,127,124,10,88,0,47,0,60,130,0,127,92,38,33,0,0,0,0,128,0,127,254,0,1,0,0,0,0,128,0,127,254,0,1,0,0,0,0,128,0,127,254,0,1,0,0,0,0,128,0,127,254,0,1,0,0,0,0,128,0,127,254,0,1,0,0,0,0,128,0,127,254,0,1,0,0,0,0,128,0,127,254,0,1,0,0,0,0,128,0,127,254,0,1,0,0,0,0,128,0,127,254,0,1,0,0,0,0,128,0,127,254,0,1,0,0,0,0,128,0,127,254,0,1,0,14,0,40,128,0,127,254,0,1,0,16,0,44,128,0,127,254,0,1,0,0,0,0,128,0,127,254,0,1,0,20,0,54,128,0,127,254,0,1,29,98,0,0,0,14,26,0,0,0,1,0,1,31,0,0,0,0,0,0,0,172,0,84,73,123,183,196,139,0,18,0,41,127,255,127,255,0,0,0,17,0,42,127,92,125,201,9,1,0,16,0,40,127,255,127,255,0,0,0,22,0,39,127,255,127,255,0,0,0,28,0,39,127,255,127,255,0,0,0,18,0,44,127,255,127,255,0,0,0,25,0,42,127,86,126,104,8,249,0,26,0,41,127,74,126,117,9,45,0,32,0,40,127,255,127,255,0,0,0,41,0,38,126,82,127,7,17,170,0,50,0,38,127,255,127,255,0,0,0,33,0,42,127,255,127,255,0,0,0,42,0,41,126,136,127,38,17,159,0,51,0,41,126,145,128,74,17,87,0,15,0,40,127,255,127,255,0,0,0,16,0,43,127,104,125,176,8,250,0,13,0,40,127,255,127,255,0,0,0,17,0,51,127,255,127,255,0,0,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,127,173,0,89,19,137,194,180,139];
+
+// length 629
+
+/* eslint-enable */
+const skeletonMessage = {
+  type: BinaryType.SKELETON,
+  data: new Uint8Array(skeletonData),
+};
+
 let consoleWarnSpy;
 
 test.before(() => {
@@ -231,6 +245,22 @@ test('should parse an invalid person_update message', t => {
 test('should parse a content message', t => {
   const msg = MessageFactory.parse(contentMessage);
   t.is(msg instanceof ContentMessage, true);
+});
+
+test('should parse a binary skeleton message', t => {
+  const msg = MessageFactory.parse(skeletonMessage);
+  t.is(msg instanceof SkeletonMessage, true);
+  t.is((msg as SkeletonMessage).personsCount, 3);
+  t.is((msg as SkeletonMessage).personLength, (629 - 2) / 3);
+});
+
+test('should parse an unknown message (invalid skeleton message)', t => {
+  const invalidSkeletonMessage = {
+    type: BinaryType.SKELETON,
+    data: new Uint8Array(skeletonData.slice(0, skeletonData.length - 3)),
+  };
+  const msg = MessageFactory.parse(invalidSkeletonMessage);
+  t.is(msg instanceof UnknownMessage, true);
 });
 
 test.after(() => {

--- a/src/messages/MessageFactory.ts
+++ b/src/messages/MessageFactory.ts
@@ -3,29 +3,33 @@ import { PersonDetectionMessage } from './person-detection/PersonDetectionMessag
 import { PersonsAliveMessage } from './persons-alive/PersonsAliveMessage';
 import { ContentMessage } from './content/ContentMessage';
 import { UnknownMessage } from './unknown/UnknownMessage';
+import { SkeletonMessage } from './skeleton/SkeletonMessage';
 import { RPCResponseSubject } from '../constants/Constants';
+import { BinaryType, BinaryMessageEvent } from '../types';
 
 /**
  * Factory class for parsing incomming messages
  */
 export class MessageFactory {
   /**
-   * Parses a string into one of the valid Message types.
+   * Parses a message into one of the valid Message types.
    *
-   * @param {Object} json the message received, parsed.
+   * @param {Object|BinaryMessageEvent} obj the message received, parsed.
    * @return {Message} a subclass of Message. Check the Message class
    * and its subclasses for more information about the valid message types.
    */
-  public static parse(json: Object): Message {
+  public static parse(obj: Object | BinaryMessageEvent): Message {
     try {
-      let msg: Message = new UnknownMessage(json);
+      let msg: Message = new UnknownMessage(obj);
 
-      if (json['subject'] == RPCResponseSubject.PersonUpdate) {
-        msg = new PersonDetectionMessage(json);
-      } else if (json['subject'] == RPCResponseSubject.PersonsAlive) {
-        msg = new PersonsAliveMessage(json);
-      } else if (json['data'] && json['data']['record_type'] == 'content_event') {
-        msg = new ContentMessage(json);
+      if (obj.hasOwnProperty('type') && obj['type'] === BinaryType.SKELETON) {
+        msg = new SkeletonMessage(obj);
+      } else if (obj['subject'] == RPCResponseSubject.PersonUpdate) {
+        msg = new PersonDetectionMessage(obj);
+      } else if (obj['subject'] == RPCResponseSubject.PersonsAlive) {
+        msg = new PersonsAliveMessage(obj);
+      } else if (obj['data'] && obj['data']['record_type'] == 'content_event') {
+        msg = new ContentMessage(obj);
       }
       return msg;
     } catch (e) {

--- a/src/messages/skeleton/SkeletonMessage.ts
+++ b/src/messages/skeleton/SkeletonMessage.ts
@@ -1,0 +1,76 @@
+import { Message } from '../Message';
+import { BinaryType, BinaryMessageEvent } from '../../types';
+
+/**
+ * Encapsulates a Binary message
+ */
+export class SkeletonMessage extends Message {
+  public data: Uint8Array;
+  public personsCount: number;
+  public personLength: number;
+
+  /**
+   * Parses a BinaryMessage
+   *
+   * @param {BinaryMessageEvent} e the message to parse
+   */
+  protected fromObject(e: BinaryMessageEvent): void {
+    this.data = e.data;
+    this.personsCount = e.data[0] * 256 + e.data[1];
+    this.personLength = (e.data.length - 2) / this.personsCount;
+  }
+
+  /**
+   * Validates a BinaryMessage
+   *
+   * @param {any} obj the message to validate
+   */
+  protected validate(obj: any): void {
+    const typeValid =
+      obj.hasOwnProperty('type') &&
+      obj['type'] === BinaryType.SKELETON &&
+      obj.hasOwnProperty('data') &&
+      obj['data'] instanceof Uint8Array;
+
+    if (!typeValid) {
+      throw new Error('Invalid SkeletonMessage type');
+    }
+
+    const data = obj.data;
+    const personsCount = data[0] * 256 + data[1];
+    const personLength = (data.length - 2) / personsCount;
+    if (
+      personsCount > 0 &&
+      personLength <
+        SkeletonMessage.skeletonBytesLength() + SkeletonMessage.personAttributesBytesLength()
+    ) {
+      throw new Error(
+        `Invalid SkeletonMessage: unexpected binary data ${
+          data.length
+        } (expected multiple of ${personLength})`
+      );
+    }
+  }
+
+  /**
+   * Return the bytes length of a skeleton
+   * @return {number}
+   */
+  private static skeletonBytesLength(): number {
+    // 18 joints with x_2d, y_2d, x_3d, y_3d, z_3d encoded with 2 bytes each
+    return 18 * 5 * 2;
+  }
+
+  /**
+   * Return the bytes length of the person attributes
+   * @return {number}
+   */
+  private static personAttributesBytesLength(): number {
+    // 1 byte age
+    // 20 bytes face attributes
+    // 1 byte ttid
+    // 1 byte recognition
+    // 3*2 bytes face angle
+    return 29;
+  }
+}

--- a/src/poi/POISnapshot.ts
+++ b/src/poi/POISnapshot.ts
@@ -1,6 +1,7 @@
 import { Message } from '../messages/Message';
 import { PersonDetectionMessage } from '../messages/person-detection/PersonDetectionMessage';
 import { PersonsAliveMessage } from '../messages/persons-alive/PersonsAliveMessage'; // eslint-disable-line max-len
+import { SkeletonMessage } from '../messages/skeleton/SkeletonMessage';
 import { ContentMessage } from '../messages/content/ContentMessage';
 import { PersonDetection } from '../model/person-detection/PersonDetection';
 import { Content } from '../model/content/Content';
@@ -62,13 +63,12 @@ export class POISnapshot {
    * different types of Messages that can be received.
    */
   public update(message: Message) {
-    if (message instanceof PersonDetectionMessage) {
+    if (message instanceof SkeletonMessage) {
+    } else if (message instanceof PersonDetectionMessage) {
       this.updatePersons(message);
-    }
-    if (message instanceof PersonsAliveMessage) {
+    } else if (message instanceof PersonsAliveMessage) {
       this.updatePersonsAlive(message);
-    }
-    if (message instanceof ContentMessage) {
+    } else if (message instanceof ContentMessage) {
       this.updateContent(message);
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,12 @@
+export enum BinaryType {
+  IMAGE,
+  SKELETON,
+  THUMBNAIL,
+  HEATMAP,
+  DEPTHMAP,
+}
+
+export interface BinaryMessageEvent {
+  type: BinaryType;
+  data: Uint8Array;
+}


### PR DESCRIPTION
Here are some fixes regarding the binary stream. The public API is changed but since the `binaryStreamMessages` method was not used, I made a minor version bump. You can now consuming the raw binary stream of image, skeleton, thumbnail, heatmap and depthmap data (in theory, the POISnapshot stream will be enough for most users).

```ts
import {IO} from '@advertima/io';

//...

io.skeletonStreamMessages().subscribe(msg => ...);

```

Basically, I implemented the `SkeletonMessage`. The validation logic is taken from the [js-libs code](https://bitbucket.org/advertima/js-libraries/src/0e590547b2754080f49c19377b1f1b6f746e0c27/libs/stork.js#lines-19). Once, this message is created it also ends up in the `POIMonitor` who dispatches it to the `POISnapshot`.

In the next PR, the idea will be to combine `PersonsAliveMessage`, `PersonDetectionMessage` and `SkeletonMessage` in order to build the `POISnapshot`, following the same logic as [here](https://bitbucket.org/advertima/js-libraries/src/development/libs/stork.js). 