### PR TITLE
Add skeleton to person detection (breaking changes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ lib
 coverage/**/*
 .nyc_output
 testresults.xml
+docs/generated/typedoc
+docs/generated/*.png
 node_modules
 .rpt2_cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,6 +483,56 @@
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "5.0.1",
+      "resolved": "http://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
+      "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/handlebars": {
+      "version": "4.0.36",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.36.tgz",
+      "integrity": "sha512-LjNiTX7TY7wtuC6y3QwC93hKMuqYhgV9A1uXBKNvZtVC8ZvyWAjZkJ5BvT0K7RKqORRYRLMrqCxpw5RgS+MdrQ==",
+      "dev": true
+    },
+    "@types/highlight.js": {
+      "version": "9.12.2",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.2.tgz",
+      "integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.104",
+      "resolved": "http://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz",
+      "integrity": "sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ==",
+      "dev": true
+    },
+    "@types/marked": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.3.0.tgz",
+      "integrity": "sha512-CSf9YWJdX1DkTNu9zcNtdCcn6hkRtB5ILjbhRId4ZOQqx30fXmdecuaXhugQL6eyrhuXtaHJ7PHI+Vm7k9ZJjg==",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/msgpack-lite": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@types/msgpack-lite/-/msgpack-lite-0.1.6.tgz",
@@ -497,6 +547,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.7.tgz",
       "integrity": "sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg==",
       "dev": true
+    },
+    "@types/shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha512-M2giRw93PxKS7YjU6GZjtdV9HASdB7TWqizBXe4Ju7AqbKlWvTr0gNO92XH56D/gMxqD/jNHLNfC5hA34yGqrQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "@types/sinon": {
       "version": "5.0.5",
@@ -1053,6 +1113,15 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
+    },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10"
+      }
     },
     "async-each": {
       "version": "1.0.1",
@@ -3715,6 +3784,26 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "handlebars": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
+      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "dev": true,
+      "requires": {
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -3859,6 +3948,12 @@
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
+    },
+    "highlight.js": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -4011,6 +4106,12 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
       "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
     },
     "irregular-plurals": {
       "version": "2.0.0",
@@ -4986,6 +5087,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "dev": true
     },
     "matcher": {
       "version": "1.1.1",
@@ -6607,6 +6714,24 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -7508,6 +7633,15 @@
         }
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "redent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -8004,6 +8138,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+      "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -8684,6 +8829,56 @@
       "integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw=",
       "dev": true
     },
+    "typedoc": {
+      "version": "0.11.1",
+      "resolved": "http://registry.npmjs.org/typedoc/-/typedoc-0.11.1.tgz",
+      "integrity": "sha512-jdNIoHm5wkZqxQTe/g9AQ3LKnZyrzHXqu6A/c9GUOeJyBWLxNr7/Dm3rwFvLksuxRNwTvY/0HRDU9sJTa9WQSg==",
+      "dev": true,
+      "requires": {
+        "@types/fs-extra": "5.0.1",
+        "@types/handlebars": "4.0.36",
+        "@types/highlight.js": "9.12.2",
+        "@types/lodash": "4.14.104",
+        "@types/marked": "0.3.0",
+        "@types/minimatch": "3.0.3",
+        "@types/shelljs": "0.7.8",
+        "fs-extra": "^5.0.0",
+        "handlebars": "^4.0.6",
+        "highlight.js": "^9.0.0",
+        "lodash": "^4.17.5",
+        "marked": "^0.3.17",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.0",
+        "shelljs": "^0.8.1",
+        "typedoc-default-themes": "^0.5.0",
+        "typescript": "2.7.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "typescript": {
+          "version": "2.7.2",
+          "resolved": "http://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+          "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+          "dev": true
+        }
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
+      "dev": true
+    },
     "typescript": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
@@ -8705,6 +8900,26 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
+        }
+      }
+    },
+    "uglify-js": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "prepare": "npm run build",
     "checkstyle": "eslint src --ext ts",
     "checkstyle:fix": "eslint src --ext ts --fix",
-    "prettier": "prettier --config ./.prettierrc.yml --write 'src/**/*.ts'"
+    "prettier": "prettier --config ./.prettierrc.yml --write 'src/**/*.ts'",
+    "docs": "cd docs && ./generate-docs.sh"
   },
   "repository": {
     "type": "git",
@@ -64,6 +65,7 @@
     "rollup-plugin-typescript2": "^0.17.1",
     "sinon": "^7.0.0",
     "ts-node": "^7.0.1",
+    "typedoc": "^0.11.1",
     "typescript": "^2.9.2",
     "typescript-eslint-parser": "^16.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/connection/WSConnection.ts
+++ b/src/connection/WSConnection.ts
@@ -1,8 +1,6 @@
 import { Observable } from 'rxjs';
 import { BinaryMessageEvent } from '../types';
 
-export const WSConnectionType = Symbol.for('WSConnectionType');
-
 export enum WSConnectionStatus {
   Open = 'open',
   Closed = 'closed',

--- a/src/incoming-message/IncomingMessageService.ts
+++ b/src/incoming-message/IncomingMessageService.ts
@@ -1,8 +1,6 @@
 import { Observable } from 'rxjs';
 import { BinaryMessageEvent, BinaryType } from '../types';
 
-export const IncomingMessageServiceType = Symbol.for('IncomingMessageServiceType');
-
 export interface IncomingMessageService {
   jsonStreamMessages(): Observable<any>;
   binaryStreamMessages(type?: BinaryType): Observable<BinaryMessageEvent>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,5 @@ export * from './io-service/IOService';
 export * from './event/ContentEvent';
 export * from './event/EventMonitor';
 export * from './constants/Constants';
-export * from './connection/WSConnection';
-export * from './incoming-message/IncomingMessageService';
-export * from './rpc/RPCService';
 export * from './io/IO';
 export * from './types';

--- a/src/messages/MessageFactory.ts
+++ b/src/messages/MessageFactory.ts
@@ -4,7 +4,7 @@ import { PersonsAliveMessage } from './persons-alive/PersonsAliveMessage';
 import { ContentMessage } from './content/ContentMessage';
 import { UnknownMessage } from './unknown/UnknownMessage';
 import { SkeletonMessage } from './skeleton/SkeletonMessage';
-import { RPCResponseSubject } from '../constants/Constants';
+import { RPCResponseSubject, RPCRecordType } from '../constants/Constants';
 import { BinaryType, BinaryMessageEvent } from '../types';
 
 /**
@@ -28,7 +28,7 @@ export class MessageFactory {
         msg = new PersonDetectionMessage(obj);
       } else if (obj['subject'] == RPCResponseSubject.PersonsAlive) {
         msg = new PersonsAliveMessage(obj);
-      } else if (obj['data'] && obj['data']['record_type'] == 'content_event') {
+      } else if (obj['data'] && obj['data']['record_type'] == RPCRecordType.ContentEvent) {
         msg = new ContentMessage(obj);
       }
       return msg;

--- a/src/messages/skeleton/SkeletonMessage.ts
+++ b/src/messages/skeleton/SkeletonMessage.ts
@@ -1,5 +1,7 @@
 import { Message } from '../Message';
 import { BinaryType, BinaryMessageEvent } from '../../types';
+import { PersonAttributes } from '../../model/person-attributes/PersonAttributes';
+import { Skeleton } from '../../model/skeleton/Skeleton';
 
 /**
  * Encapsulates a Binary message
@@ -38,11 +40,10 @@ export class SkeletonMessage extends Message {
 
     const data = obj.data;
     const personsCount = data[0] * 256 + data[1];
-    const personLength = (data.length - 2) / personsCount;
+    const personLength = personsCount === 0 ? 0 : (data.length - 2) / personsCount;
     if (
       personsCount > 0 &&
-      personLength <
-        SkeletonMessage.skeletonBytesLength() + SkeletonMessage.personAttributesBytesLength()
+      personLength < Skeleton.bytesLength() + PersonAttributes.bytesLength()
     ) {
       throw new Error(
         `Invalid SkeletonMessage: unexpected binary data ${
@@ -50,27 +51,5 @@ export class SkeletonMessage extends Message {
         } (expected multiple of ${personLength})`
       );
     }
-  }
-
-  /**
-   * Return the bytes length of a skeleton
-   * @return {number}
-   */
-  private static skeletonBytesLength(): number {
-    // 18 joints with x_2d, y_2d, x_3d, y_3d, z_3d encoded with 2 bytes each
-    return 18 * 5 * 2;
-  }
-
-  /**
-   * Return the bytes length of the person attributes
-   * @return {number}
-   */
-  private static personAttributesBytesLength(): number {
-    // 1 byte age
-    // 20 bytes face attributes
-    // 1 byte ttid
-    // 1 byte recognition
-    // 3*2 bytes face angle
-    return 29;
   }
 }

--- a/src/model/content/Content.ts
+++ b/src/model/content/Content.ts
@@ -26,4 +26,19 @@ export class Content {
 
     return content;
   }
+
+  /**
+   * Returns a new instance of Content
+   * containing the configuration
+   * @return {Content} cloned instance
+   */
+  public clone(): Content {
+    const content = new Content();
+    content.poi = this.poi;
+    content.localTimestamp = this.localTimestamp;
+    content.event = this.event;
+    content.contentId = this.contentId;
+    content.personPutIds = this.personPutIds;
+    return content;
+  }
 }

--- a/src/model/person-attributes/PersonAttributes.ts
+++ b/src/model/person-attributes/PersonAttributes.ts
@@ -8,7 +8,7 @@ function decodeHeadposeAngle(data: Uint8Array, offset: number): number {
   return ((data[offset] * 256 + data[offset + 1]) / (256 * 256)) * 180 - 90;
 }
 
-const indices = {
+export const indices = {
   male: 1,
   bald: 2,
   black_hair: 3,

--- a/src/model/person-attributes/PersonAttributes.ts
+++ b/src/model/person-attributes/PersonAttributes.ts
@@ -1,0 +1,117 @@
+/**
+ * Decodes the headpose angle
+ * @param {Uint8Array} data   [description]
+ * @param {number} offset [description]
+ * @return {number}       [description]
+ */
+function decodeHeadposeAngle(data: Uint8Array, offset: number): number {
+  return ((data[offset] * 256 + data[offset + 1]) / (256 * 256)) * 180 - 90;
+}
+
+const indices = {
+  male: 1,
+  bald: 2,
+  black_hair: 3,
+  blond_hair: 4,
+  blurry: 5,
+  brown_hair: 6,
+  chubby: 7,
+  double_chin: 8,
+  eyeglasses: 9,
+  goatee: 10,
+  gray_hair: 11,
+  mustache: 12,
+  no_beard: 13,
+  receding_hairline: 14,
+  smiling: 15,
+  wearing_earrings: 16,
+  wearing_hat: 17,
+  wearing_lipstick: 18,
+  wearing_necklace: 19,
+  wearing_necktie: 20,
+};
+
+/**
+ * Represents the person attributes
+ */
+export class PersonAttributes {
+  /* eslint-disable camelcase */
+  public age: number;
+  public ttid: number;
+  public isRecognized: boolean;
+  public headpose: {
+    yaw: number;
+    pitch: number;
+    roll: number;
+  };
+  public male: number;
+  public bald: number;
+  public black_hair: number;
+  public blond_hair: number;
+  public blurry: number;
+  public brown_hair: number;
+  public chubby: number;
+  public double_chin: number;
+  public eyeglasses: number;
+  public goatee: number;
+  public gray_hair: number;
+  public mustache: number;
+  public no_beard: number;
+  public receding_hairline: number;
+  public smiling: number;
+  public wearing_earrings: number;
+  public wearing_hat: number;
+  public wearing_lipstick: number;
+  public wearing_necklace: number;
+  public wearing_necktie: number;
+  /* eslint-enable camelcase */
+
+  /**
+   * Parses the binary data and create the person attributes
+   * @param {Uint8Array} data [description]
+   */
+  constructor(data: Uint8Array) {
+    if (!data || !data.length || data.length < PersonAttributes.bytesLength()) {
+      throw new Error(
+        `Invalid PersonAttributes data with length ${(data && data.length) ||
+          'N/A'} (expected ${PersonAttributes.bytesLength()}).`
+      );
+    }
+    this.age = data[0] == 127 ? undefined : data[0];
+    this.ttid = data[21];
+    this.isRecognized = data[22] == 1 ? true : false;
+    this.headpose = {
+      yaw: decodeHeadposeAngle(data, 23),
+      pitch: decodeHeadposeAngle(data, 25),
+      roll: decodeHeadposeAngle(data, 27),
+    };
+
+    for (const name in indices) {
+      if (indices.hasOwnProperty(name)) {
+        const percentage = data[indices[name]];
+        // 127 represents undefined by the server
+        if (percentage == 127) {
+          this[name] = undefined;
+        } else if (percentage == undefined || percentage < 0 || percentage > 100) {
+          console.error(`FaceAttribute ${name} has invalid percentage ${percentage}`);
+          this[name] = undefined;
+        } else {
+          this[name] = percentage / 100.0;
+        }
+      }
+    }
+  }
+
+  /**
+   * Return the bytes length of the person attributes
+   * @return {number}
+   */
+  public static bytesLength(): number {
+    // 1 byte age
+    // 20 bytes face attributes
+    // 1 byte ttid
+    // 1 byte recognition
+    // 3*2 bytes face angle
+    return 29;
+  }
+}

--- a/src/model/person-detection/PersonDetection.ts
+++ b/src/model/person-detection/PersonDetection.ts
@@ -1,31 +1,39 @@
 import { PersonDetectionMessage } from '../../messages/person-detection/PersonDetectionMessage';
-
-export interface PersonCoordinates {
-  x: number;
-  y: number;
-  z: number;
-}
+import { BinaryCachedData, Skeleton } from '../../model/skeleton/Skeleton';
+import { PersonAttributes } from '../../model/person-attributes/PersonAttributes';
 
 export interface RecognitionMetadta {
   name: string;
 }
 
 /**
- * Represents a person
+ * Person Detection model
  */
 export class PersonDetection {
-  public age: number;
-  public gender: string;
-  public ttid: string;
-  public personId: string;
-  public personPutId: string;
-  public coordinates: PersonCoordinates;
-  public metadata: RecognitionMetadta;
+  private skeleton: Skeleton;
+  private personAttributes: PersonAttributes;
+  private json: PersonDetectionMessage;
+
   public updated = new Date().getTime();
-  public localTimestamp: number = 0;
-  public lookingAtScreen: number;
-  public cameraId: string;
-  public poi: number;
+
+  /**
+   * Last timestamp of the person detection
+   * @return {number} [description]
+   */
+  get localTimestamp(): number {
+    if (this.json.localTimestamp) {
+      this.updated = this.json.localTimestamp;
+    }
+    return this.json.localTimestamp;
+  }
+
+  /**
+   * Id of the PoI
+   * @return {number}
+   */
+  get poi(): number {
+    return this.json.poi;
+  }
 
   /**
    * Returns the name of the recognised person
@@ -33,10 +41,42 @@ export class PersonDetection {
    * @return {string} the name of the recognised person
    */
   get name(): string {
-    if (this.metadata && this.metadata.name) {
-      return this.metadata.name;
+    if (this.recognition && this.recognition.name) {
+      return this.recognition.name;
     }
     return null;
+  }
+
+  /**
+   * Gender of the person
+   * @return {string} 'male if the person is a male, 'female' otherwise
+   */
+  get gender(): string {
+    return this.isMale ? 'male' : 'female';
+  }
+
+  /**
+   * Person ID
+   * @return {string}
+   */
+  get personId(): string {
+    return this.json.personId;
+  }
+
+  /**
+   * Person PUT id
+   * @return {string}
+   */
+  get personPutId(): string {
+    return this.json.personPutId;
+  }
+
+  /**
+   * Recognition metadata
+   * @return {RecognitionMetadta}
+   */
+  get recognition(): RecognitionMetadta {
+    return this.json.recognition as RecognitionMetadta;
   }
 
   /**
@@ -45,33 +85,188 @@ export class PersonDetection {
    * @return {boolean} true if the person is looking at the screen,
    * false otherwise.
    */
-  isLookingAtScreen(): boolean {
-    return this.lookingAtScreen == 0;
+  get isLookingAtScreen(): boolean {
+    return this.json.lookingAtScreen == 0;
+  }
+
+  /**
+   * Camera ID
+   * @return {string}
+   */
+  get cameraId(): string {
+    return this.json.cameraId;
+  }
+
+  /**
+   * Returing 3d x-coordinate of the persons's body in meters
+   * @return  {number}
+   */
+  get u(): number {
+    return this.skeleton.neckU;
+  }
+
+  /**
+   * Returing 3d y-coordinate of the persons's body in meters
+   * @return  {number}
+   */
+  get v(): number {
+    return this.skeleton.neckV;
+  }
+
+  /**
+   * Returing 3d z-coordinate of the persons's body
+   * @return  {number}
+   */
+  get z(): number {
+    return this.skeleton.neckZ;
+  }
+
+  /**
+   * Is true if the person is a male
+   * @return  {boolean}
+   */
+  get isMale(): boolean {
+    const male = this.likelihoodMale;
+    return male != undefined && male >= 0.5;
+  }
+
+  /**
+   * Is true is the person is a female
+   * @return {boolean}
+   */
+  get isFemale(): boolean {
+    const male = this.likelihoodMale;
+    return male != undefined && male < 0.5;
+  }
+
+  /**
+   * Person age
+   * @return {number}
+   */
+  get age(): number {
+    return this.personAttributes.age;
+  }
+
+  /**
+   * Probability that the person is a male
+   * @return {number}
+   */
+  get likelihoodMale(): number {
+    return this.personAttributes.male;
+  }
+
+  /**
+   * Wether the person is recognized or not
+   * @return {boolean}
+   */
+  get isRecognized(): boolean {
+    return this.personAttributes.isRecognized;
+  }
+
+  /**
+   * ttid of the person
+   * @return {number}
+   */
+  get ttid(): number {
+    return this.personAttributes.ttid;
+  }
+
+  /**
+   * Headpose object
+   * @return {{yaw, pitch, roll}}
+   */
+  get headpose(): {
+    yaw: number;
+    pitch: number;
+    roll: number;
+  } {
+    return this.personAttributes.headpose;
+  }
+
+  /**
+   * Ttid encapsulated in an object
+   * @return {{ttid: number}} [description]
+   */
+  get onlyTtid(): { ttid: number } {
+    return {
+      ttid: this.ttid,
+    };
+  }
+
+  /**
+   * Robust face attributes merged with ttid
+   * @return {Object}
+   */
+  get robustFaceAttributes(): Object {
+    return {
+      ...this.onlyTtid,
+      male: this.personAttributes.male,
+      eyeglasses: this.personAttributes.eyeglasses,
+      wearing_hat: this.personAttributes.wearing_hat,
+      wearing_lipstick: this.personAttributes.wearing_lipstick,
+    };
+  }
+
+  /**
+   * Face attributes merged with the robust face attributes and the ttid
+   * @return {Object}
+   */
+  get allFaceAttributes(): Object {
+    return {
+      ...this.onlyTtid,
+      ...this.robustFaceAttributes,
+      smiling: this.personAttributes.smiling,
+      bald: this.personAttributes.bald,
+      gray_hair: this.personAttributes.gray_hair,
+      black_hair: this.personAttributes.black_hair,
+      blond_hair: this.personAttributes.blond_hair,
+      brown_hair: this.personAttributes.brown_hair,
+      receding_hairline: this.personAttributes.receding_hairline,
+      blurry: this.personAttributes.blurry,
+      chubby: this.personAttributes.chubby,
+      double_chin: this.personAttributes.double_chin,
+      goatee: this.personAttributes.goatee,
+      mustache: this.personAttributes.mustache,
+      no_beard: this.personAttributes.no_beard,
+      wearing_earrings: this.personAttributes.wearing_earrings,
+      wearing_necklace: this.personAttributes.wearing_necklace,
+      wearing_necktie: this.personAttributes.wearing_necktie,
+    };
+  }
+
+  /**
+   * Updates a person from json data
+   * @param {PersonDetectionMessage} json data
+   */
+  public updateFromJson(json: PersonDetectionMessage): void {
+    if (this.personId !== undefined && this.personId != json.personId) {
+      throw new Error('Precondition failed, changing person_id.');
+    }
+    this.json = json;
+  }
+
+  /**
+   * Update the person from binary data
+   * @param {BinaryCachedData} binary data
+   */
+  public updateFromBinary(binary: BinaryCachedData): void {
+    this.skeleton = binary.skeleton;
+    this.personAttributes = binary.personAttributes;
   }
 
   /**
    * Creates a Person object from a Person message
-   * @param  {PersonDetectionMessage} message
+   * @param  {PersonDetectionMessage} json
+   * @param  {BinaryCachedData} cache
    * @return {PersonDetection}        the person entity
    */
-  static fromMessage(message: PersonDetectionMessage): PersonDetection {
+  static fromMessage(json: PersonDetectionMessage, cache: BinaryCachedData): PersonDetection {
     const person = new PersonDetection();
-    person.ttid = message.ttid;
-    person.personId = message.personId;
-    person.personPutId = message.personPutId;
-    person.age = message.age;
-    person.gender = message.gender;
-    person.localTimestamp = message.localTimestamp;
-    person.coordinates = message['coordinates'] as PersonCoordinates;
-    person.metadata = message.recognition as RecognitionMetadta;
-    person.lookingAtScreen = message.lookingAtScreen;
-    person.poi = message.poi;
 
-    if (person.localTimestamp) {
-      person.updated = person.localTimestamp;
-    }
+    person.json = json;
+    person.skeleton = cache.skeleton;
+    person.personAttributes = cache.personAttributes;
 
-    person.cameraId = message.cameraId;
     return person;
   }
 }

--- a/src/model/skeleton/Skeleton.ts
+++ b/src/model/skeleton/Skeleton.ts
@@ -1,0 +1,367 @@
+import { PersonAttributes } from '../person-attributes/PersonAttributes';
+
+export interface BinaryCachedData {
+  skeleton: Skeleton;
+  personAttributes: PersonAttributes;
+}
+
+/* eslint-disable camelcase */
+export interface Limbs {
+  nose: number;
+  neck: number;
+  left_eye: number;
+  right_eye: number;
+  left_ear: number;
+  right_ear: number;
+  left_hip: number;
+  right_hip: number;
+  right_shoulder: number;
+  right_elbow: number;
+  right_hand: number;
+  left_shoulder: number;
+  left_elbow: number;
+  left_hand: number;
+}
+
+/**
+ * Skeleton model
+ */
+export class Skeleton {
+  public limbs: Limbs = {
+    nose: 0,
+    neck: 1,
+
+    left_eye: 15,
+    right_eye: 14,
+
+    left_ear: 17,
+    right_ear: 16,
+
+    left_hip: 11,
+    right_hip: 8,
+
+    right_shoulder: 2,
+    right_elbow: 3,
+    right_hand: 4,
+
+    left_shoulder: 5,
+    left_elbow: 6,
+    left_hand: 7,
+  };
+
+  /**
+   * Instantiate a Skeleton from a data provider
+   * @param {SkeletonBinaryDataProvider} dataProvider
+   */
+  constructor(private dataProvider: SkeletonBinaryDataProvider) {}
+
+  /**
+   * Position of the right hand
+   * @return {{x: number, y: number, z: number}}
+   */
+  get rightHand(): { x: number; y: number; z: number } {
+    return this.position(this.limbs.right_hand);
+  }
+
+  /**
+   * Position of the left shoulder
+   * @return {{x: number, y: number, z: number}}
+   */
+  get leftShoulder(): { x: number; y: number; z: number } {
+    return this.position(this.limbs.left_shoulder);
+  }
+
+  /**
+   * Position of the right shoulder
+   * @return {{x: number, y: number, z: number}}
+   */
+  get rightShoulder(): { x: number; y: number; z: number } {
+    return this.position(this.limbs.right_shoulder);
+  }
+
+  /**
+   * Position of the nose
+   * @return {{x: number, y: number, z: number}}
+   */
+  get nose(): { x: number; y: number; z: number } {
+    return this.position(this.limbs.nose);
+  }
+
+  /**
+   * Position of the left ear
+   * @return {{x: number, y: number, z: number}}
+   */
+  get left_ear(): { x: number; y: number; z: number } {
+    return this.position(this.limbs.left_ear);
+  }
+
+  /**
+   * x coordinate of the neck
+   * @return {number}
+   */
+  get neckX(): number {
+    return this.limbX(this.limbs.neck);
+  }
+
+  /**
+   * 3d x coordinate of the neck
+   * @return {number}
+   */
+  get neckU(): number {
+    return this.limbU(this.limbs.neck);
+  }
+
+  /**
+   * 3d y coordinate of the neck
+   * @return {number}
+   */
+  get neckV(): number {
+    return this.limbV(this.limbs.neck);
+  }
+
+  /**
+   * 3d z coordinate of the neck
+   * @return {number}
+   */
+  get neckZ(): number {
+    return this.limbZ(this.limbs.neck);
+  }
+
+  /**
+   * Wether the skeleton has a nose
+   * @return {boolean} true of the skeleton has a nose
+   */
+  get hasNose(): boolean {
+    return this.hasLimb(this.limbs.nose);
+  }
+
+  /**
+   * Wether the skeleton has a beck
+   * @return {boolean} true of the skeleton has a beck
+   */
+  get hasNeck(): boolean {
+    return this.hasLimb(this.limbs.neck);
+  }
+
+  /**
+   * Wether the skeleton has a left ear
+   * @return {boolean} true of the skeleton has a left ear
+   */
+  get hasLeftEar(): boolean {
+    return this.hasLimb(this.limbs.left_ear);
+  }
+
+  /**
+   * Wether the skeleton has a left eye
+   * @return {boolean} true of the skeleton has a left eye
+   */
+  get hasLeftEye(): boolean {
+    return this.hasLimb(this.limbs.left_eye);
+  }
+
+  /**
+   * Wether the skeleton has a right ear
+   * @return {boolean} true of the skeleton has a right ear
+   */
+  get hasRightEar(): boolean {
+    return this.hasLimb(this.limbs.right_ear);
+  }
+
+  /**
+   * Wether the skeleton has a right eye
+   * @return {boolean} true of the skeleton has a right eye
+   */
+  get hasRightEye(): boolean {
+    return this.hasLimb(this.limbs.right_eye);
+  }
+
+  /**
+   * Wether the skeleton has a right shoulder
+   * @return {boolean} true of the skeleton has a right shoulder
+   */
+  get hasRightShoulder(): boolean {
+    return this.hasLimb(this.limbs.right_shoulder);
+  }
+
+  /**
+   * Wether the skeleton has a left shoulder
+   * @return {boolean} true of the skeleton has a left shoulder
+   */
+  get hasLeftShoulder(): boolean {
+    return this.hasLimb(this.limbs.left_shoulder);
+  }
+
+  /**
+   * Wether the skeleton has a left hip
+   * @return {boolean} true of the skeleton has a left hip
+   */
+  get hasLeftHip(): boolean {
+    return this.hasLimb(this.limbs.left_hip);
+  }
+
+  /**
+   * Wether the skeleton has a right hip
+   * @return {boolean} true of the skeleton has a right hip
+   */
+  get hasRightHip(): boolean {
+    return this.hasLimb(this.limbs.right_hip);
+  }
+
+  /**
+   * Returns the position of a limb based on its id
+   * @param {number} idx id of the limb
+   * @return {{x: number, y: number, z: number}}
+   */
+  public position(idx: number): { x: number; y: number; z: number } {
+    const x = this.limbX(idx);
+    const y = this.limbY(idx);
+    const z = this.limbZ(idx);
+    // indicating that the joint was not detected
+    if (x == undefined || y == undefined) {
+      return undefined;
+    }
+    return { x, y, z };
+  }
+
+  /**
+   * Wether the skeleton has the requested limb
+   * @param {number} idx id of the lim
+   * @return {boolean} true of the skeleton has this limb
+   */
+  public hasLimb(idx: number): boolean {
+    return this.limbX(idx) != undefined;
+  }
+
+  /**
+   * Returning y coordinate of the point
+   * @param {number} idx
+   * @return {number}
+   */
+  public limbY(idx: number): number {
+    return this.dataProvider.limbY(idx);
+  }
+
+  /**
+   * Returning x coordinate of the point
+   * @param {number} idx
+   * @return {number}
+   */
+  public limbX(idx: number): number {
+    return this.dataProvider.limbX(idx);
+  }
+
+  /**
+   * Returning the 3d x coordinate for the joint with index idx in meters
+   * @param {number} idx
+   * @return {number}
+   */
+  public limbU(idx: number): number {
+    return this.dataProvider.limbU(idx);
+  }
+
+  /**
+   * Returning the 3d y coordinate for the joint with index idx in meters
+   * @param {number} idx
+   * @return {number}
+   */
+  public limbV(idx: number): number {
+    return this.dataProvider.limbV(idx);
+  }
+
+  /**
+   * Returning the 3d z coordinate for the joint with index idx in meters
+   * @param {number} idx
+   * @return {number}
+   */
+  public limbZ(idx: number): number {
+    return this.dataProvider.limbZ(idx);
+  }
+
+  /**
+   * Return the bytes length of a skeleton
+   * @return {number}
+   */
+  public static bytesLength(): number {
+    // 18 joints with x_2d, y_2d, x_3d, y_3d, z_3d encoded with 2 bytes each
+    return 18 * 5 * 2;
+  }
+}
+
+/**
+ * Low level abstraction of the skeleton data
+ * Provides methods to calculate the value of a limb
+ */
+export class SkeletonBinaryDataProvider {
+  private data: Uint8Array;
+
+  /**
+   * Instantiate the data provider. Throws an error if the data are missing or invalid
+   * @param {Uint8Array} data
+   */
+  constructor(data: Uint8Array) {
+    if (!data || !data.length || data.length != Skeleton.bytesLength()) {
+      throw new Error(
+        `Invalid skeleton data with length ${(data && data.length) ||
+          'N/A'} (expected ${Skeleton.bytesLength()}).`
+      );
+    }
+    this.data = data;
+  }
+
+  /* eslint-disable require-jsdoc */
+  public limbY(idx: number): number {
+    const offset = 5 * 2 * idx + 0;
+    return this.limb2dValueFromBinary(offset);
+  }
+
+  public limbX(idx: number): number {
+    const offset = 5 * 2 * idx + 2;
+    return this.limb2dValueFromBinary(offset);
+  }
+
+  public limbU(idx: number): number {
+    const offset = 5 * 2 * idx + 4;
+    return this.limb3dU(offset);
+  }
+
+  public limbV(idx: number): number {
+    const offset = 5 * 2 * idx + 6;
+    return this.limb3dV(offset);
+  }
+
+  public limbZ(idx: number): number {
+    const offset = 5 * 2 * idx + 8;
+    return this.limb3dZ(offset);
+  }
+
+  private limb2dValueFromBinary(offset: number): number {
+    const value = this.data[offset] * 256 + this.data[offset + 1];
+    // value of zero cannot exist, unless the joint is not detected
+    if (value == 0) {
+      return undefined;
+    }
+    return value;
+  }
+
+  private limb3dZ(offset: number): number {
+    // z-joints are encoded for a range of 0m to 20m
+    return this.limb3d(offset, 0, 20);
+  }
+
+  private limb3dU(offset: number): number {
+    // u-joints (3d x-coordinate) are encoded for a range of -20m to 20m
+    return this.limb3d(offset, -20, 20);
+  }
+
+  private limb3dV(offset: number): number {
+    // v-joints (3d y-coordinate) are encoded for a range of -10m to 10m
+    return this.limb3d(offset, -10, 10);
+  }
+
+  private limb3d(offset: number, min: number, max: number): number {
+    const num = this.data[offset] * 256 + this.data[offset + 1];
+    const value = (num * (max - min)) / (256 * 256) + min;
+    return value;
+  }
+  /* eslint-enable require-jsdoc */
+}

--- a/src/poi/POIMonitor.ts
+++ b/src/poi/POIMonitor.ts
@@ -16,8 +16,7 @@ import { BinaryType } from '../types';
 export class POIMonitor {
   private isActive: boolean = true;
   private isActiveTimeout;
-  private poiSnapshot: POISnapshot = new POISnapshot();
-  private snapshots: BehaviorSubject<POISnapshot> = new BehaviorSubject(this.poiSnapshot); // eslint-disable-line no-invalid-this, max-len
+  private snapshots: BehaviorSubject<POISnapshot> = new BehaviorSubject(new POISnapshot());
   private logger = console;
   private streamSubscription: Subscription;
 
@@ -60,7 +59,7 @@ export class POIMonitor {
    * @param {Message} message the message sent by the POI.
    */
   public emitSnapshot(message: Message): void {
-    this.poiSnapshot.update(message);
+    this.getSnapshot().update(message);
     if (message instanceof PersonsAliveMessage) {
       if (this.isActive) {
         this.updateHealthTimeout();
@@ -69,7 +68,7 @@ export class POIMonitor {
         this.isActive = true;
       }
     }
-    this.snapshots.next(this.poiSnapshot.clone());
+    this.snapshots.next(this.getSnapshot().clone());
   }
 
   /**
@@ -90,9 +89,9 @@ export class POIMonitor {
     this.isActiveTimeout = setTimeout(() => {
       this.isActive = false;
       this.logger.warn('PoI stopped emitting.');
-      this.poiSnapshot.setPersons(new Map());
-      this.poiSnapshot.update(new PersonsAliveMessage({ data: { person_ids: [] } }));
-      this.snapshots.next(this.poiSnapshot.clone());
+      this.getSnapshot().setPersons(new Map());
+      this.getSnapshot().update(new PersonsAliveMessage({ data: { person_ids: [] } }));
+      this.snapshots.next(this.getSnapshot().clone());
     }, 2000);
   }
 

--- a/src/poi/POISnapshot.spec.ts
+++ b/src/poi/POISnapshot.spec.ts
@@ -1,0 +1,167 @@
+import test from 'ava';
+import { POISnapshot } from './POISnapshot';
+import {
+  generatePersonDetectionMessage,
+  generateSkeletonMessage,
+  generatePersonsAliveMessage,
+  generateContentMessage,
+} from './test-utils';
+
+test('should not add the person to the snapshot when the input only contains json data', t => {
+  const snapshot = new POISnapshot();
+  const message = generatePersonDetectionMessage();
+  snapshot.update(message);
+  t.is(snapshot.getPersons().size, 0);
+});
+
+test('should not add the person to the snapshot when the input only contains binary data', t => {
+  const snapshot = new POISnapshot();
+  const message = generateSkeletonMessage([{}]); // will generate 1 person with default options
+  snapshot.update(message);
+  t.is(snapshot.getPersons().size, 0);
+});
+
+test('should throw an error when the ttid of the person is not a number', t => {
+  const snapshot = new POISnapshot();
+  const ttid = 'not a number' as any;
+  const json = generatePersonDetectionMessage({ ttid });
+  const error = t.throws(() => snapshot.update(json));
+  t.is(error.message, 'TTID must be set');
+});
+
+test('should add the person to the snapshot when both json and binary data are received', t => {
+  const snapshot = new POISnapshot();
+  const personId = '1234';
+  const ttid = 23;
+  const age = 51;
+  const json = generatePersonDetectionMessage({
+    ttid,
+    age,
+    personId,
+  });
+  const binary = generateSkeletonMessage([{ ttid, age }]);
+  snapshot.update(json);
+  snapshot.update(binary);
+  t.is(snapshot.getPersons().size, 1);
+  t.is(snapshot.getPersons().get(personId).age, age);
+});
+
+test(`
+Scenario:
+  - Add person 1,
+  - Adds person 2
+  - 20 secs later receive an update from person 2 only
+  - Receive a persons_alive message containing only [2]
+
+Expected: should have person 2 only in the snapshot
+
+`, t => {
+  const snapshot = new POISnapshot();
+  const ttid1 = 23;
+  const personId1 = '1';
+  const ttid2 = 87;
+  const personId2 = '2';
+  const json1 = generatePersonDetectionMessage({ ttid: ttid1, personId: personId1 });
+  const binary1 = generateSkeletonMessage([{ ttid: ttid1 }]);
+  const json2 = generatePersonDetectionMessage({ ttid: ttid2, personId: personId2 });
+  const binary2 = generateSkeletonMessage([{ ttid: ttid2 }]);
+
+  // simulate multiple messages
+  snapshot.update(json1);
+  snapshot.update(binary1);
+  snapshot.update(binary1);
+  snapshot.update(binary2);
+  snapshot.update(json1);
+  snapshot.update(json2);
+
+  // stamp that the message occurs 20 seconds after
+  // to simulate no event for 20 seconds
+  // (then we don't have to use setTimeout)
+  const timestamp = Date.now() + 20000;
+
+  // person 2 gets an update
+  const json2Update = generatePersonDetectionMessage({ ttid: ttid2, personId: personId2 });
+  json2Update.localTimestamp = timestamp;
+  const binary2Update = generateSkeletonMessage([{ ttid: ttid2 }]);
+  snapshot.update(json2Update);
+  snapshot.update(binary2Update);
+
+  // person 1 does not
+
+  const personsAlive = generatePersonsAliveMessage([personId2], timestamp);
+  snapshot.update(personsAlive);
+
+  t.is(snapshot.getPersons().size, 1);
+  t.not(snapshot.getPersons().get(personId2), undefined);
+  t.is(snapshot.getPersons().get(personId1), undefined);
+});
+
+test(`
+Scenario:
+  - Add person 1,
+  - Adds person 2
+  - 20 secs later receive an update from person 1 and person 2
+  - Receive a persons_alive message containing only [2]
+
+Expected: should still have person 1 and person 2 in the snapshot
+`, t => {
+  const snapshot = new POISnapshot();
+  const ttid1 = 23;
+  const personId1 = '1';
+  const ttid2 = 87;
+  const personId2 = '2';
+  const json1 = generatePersonDetectionMessage({ ttid: ttid1, personId: personId1 });
+  const binary1 = generateSkeletonMessage([{ ttid: ttid1 }]);
+  const json2 = generatePersonDetectionMessage({ ttid: ttid2, personId: personId2 });
+  const binary2 = generateSkeletonMessage([{ ttid: ttid2 }]);
+
+  // simulate multiple messages
+  snapshot.update(json1);
+  snapshot.update(binary1);
+  snapshot.update(binary1);
+  snapshot.update(binary2);
+  snapshot.update(json1);
+  snapshot.update(json2);
+
+  // stamp that the message occurs 20 seconds after
+  // to simulate no event for 20 seconds
+  // (then we don't have to use setTimeout)
+  const timestamp = Date.now() + 20000;
+
+  // person 2 gets an update
+  const json2Update = generatePersonDetectionMessage({ ttid: ttid2, personId: personId2 });
+  json2Update.localTimestamp = timestamp;
+  const binary2Update = generateSkeletonMessage([{ ttid: ttid2 }]);
+  snapshot.update(json2Update);
+  snapshot.update(binary2Update);
+
+  // person 2 gets an update
+  const json1Update = generatePersonDetectionMessage({ ttid: ttid1, personId: personId1 });
+  json1Update.localTimestamp = timestamp;
+  const binary1Update = generateSkeletonMessage([{ ttid: ttid1 }]);
+  snapshot.update(binary1Update);
+  snapshot.update(json1Update);
+
+  const personsAlive = generatePersonsAliveMessage([personId2], timestamp);
+  snapshot.update(personsAlive);
+
+  t.is(snapshot.getPersons().size, 2);
+  t.not(snapshot.getPersons().get(personId2), undefined);
+  t.not(snapshot.getPersons().get(personId1), undefined);
+});
+
+test('should have the content', t => {
+  const snapshot = new POISnapshot();
+  snapshot.update(generateContentMessage('1234', 38));
+  t.is(snapshot.getContent().contentId, '1234');
+  t.is(snapshot.getContent().poi, 38);
+});
+
+test('should clone the snapshot', t => {
+  const snapshot = new POISnapshot();
+  snapshot.update(generateContentMessage('1234', 38));
+
+  const clone = snapshot.clone();
+  t.is(clone.getContent().contentId, '1234');
+  t.is(clone.getContent().poi, 38);
+});

--- a/src/poi/POISnapshot.ts
+++ b/src/poi/POISnapshot.ts
@@ -88,13 +88,17 @@ export class POISnapshot {
 
   /**
    * Returns a new instance of POISnapshot
-   * containing the same persons and personIds
+   * containing the configuration
    * @return {POISnapshot} cloned instance
    */
   public clone(): POISnapshot {
     const snapshot = new POISnapshot();
     snapshot.persons = new Map(this.persons);
     snapshot.lastPersonUpdate = new Map(this.lastPersonUpdate);
+    snapshot.personsByTtid = new Map(this.personsByTtid);
+    snapshot.personsCache = new Map(this.personsCache);
+    snapshot.content = this.content ? this.content.clone() : undefined;
+    snapshot.lastUpdateTimestamp = this.lastUpdateTimestamp;
     return snapshot;
   }
 

--- a/src/poi/POISnapshot.ts
+++ b/src/poi/POISnapshot.ts
@@ -176,6 +176,8 @@ export class POISnapshot {
       this.createOrCachePerson(ttid, 'json', message);
     } else {
       person.updateFromJson(message);
+      this.lastPersonUpdate.set(person.personId, person.localTimestamp);
+      this.lastUpdateTimestamp = person.localTimestamp;
     }
   }
 

--- a/src/poi/test-utils/common.ts
+++ b/src/poi/test-utils/common.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns a random integer x as min <= x < max
+ * @param {number} min
+ * @param {number} max
+ * @return {number}
+ */
+export function getRandomInt(min: number, max: number): number {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  // The maximum is exclusive and the minimum is inclusive
+  return Math.floor(Math.random() * (max - min)) + min;
+}

--- a/src/poi/test-utils/index.ts
+++ b/src/poi/test-utils/index.ts
@@ -1,0 +1,4 @@
+export * from './messages/PersonDetectionMessageGenerate';
+export * from './messages/SkeletonMessageGenerate';
+export * from './messages/PersonsAliveMessageGenerate';
+export * from './messages/ContentMessageGenerate';

--- a/src/poi/test-utils/messages/ContentMessageGenerate.ts
+++ b/src/poi/test-utils/messages/ContentMessageGenerate.ts
@@ -1,0 +1,22 @@
+import { ContentMessage } from '../../../messages/content/ContentMessage';
+import { MessageFactory } from '../../../messages/MessageFactory';
+import { RPCRecordType } from '../../../constants/Constants';
+
+/**
+ * Generates a ContentMessage instance
+ * @param {string} contentId id of the content
+ * @param {number} poi id of the poi
+ * @return {ContentMessage} message
+ */
+export function generateContentMessage(contentId: string, poi: number): ContentMessage {
+  return MessageFactory.parse({
+    data: {
+      poi,
+      record_type: RPCRecordType.ContentEvent,
+      local_timestamp: Date.now(),
+      name: '',
+      content_id: contentId,
+      person_put_ids: [],
+    },
+  }) as ContentMessage;
+}

--- a/src/poi/test-utils/messages/PersonDetectionMessageGenerate.ts
+++ b/src/poi/test-utils/messages/PersonDetectionMessageGenerate.ts
@@ -1,0 +1,188 @@
+import { PersonDetectionMessage } from '../../../messages/person-detection/PersonDetectionMessage';
+import { MessageFactory } from '../../../messages/MessageFactory';
+import { getRandomInt } from '../common';
+import { RPCResponseSubject } from '../../../constants/Constants';
+
+export interface PersonOptions {
+  age?: number;
+  gender?: string;
+  name?: string;
+  z?: number;
+  ttid?: number;
+  personId?: string;
+}
+
+/**
+ * Generates a PersonDetectionMessage instance
+ * @param {PersonOptions} options to create the person
+ * @return {PersonDetectionMessage} message
+ */
+export function generatePersonDetectionMessage(
+  options: PersonOptions = {}
+): PersonDetectionMessage {
+  return MessageFactory.parse(generatePerson(options)) as PersonDetectionMessage;
+}
+
+/**
+ * Generates a person_update object
+ * @param {PersonOptions} options
+ * @return {Object}       person detection
+ */
+function generatePerson(options: PersonOptions): Object {
+  const age = options.age !== undefined ? options.age : getRandomInt(1, 101);
+  const gender = options.gender || 'female';
+  const person = {
+    person_id:
+      options.personId ||
+      `_${Math.random()
+        .toString(36)
+        .substr(2, 9)}`,
+    person_put_id: `_${Math.random()
+      .toString(36)
+      .substr(2, 9)}`,
+    behavior: {
+      body: {
+        left_arm: 0,
+        right_arm: 0,
+        raising_left_hand: 0,
+        raising_right_hand: 0,
+      },
+      head: {
+        looking_at_screen: 5,
+      },
+    },
+    coordinates: {
+      x: 0,
+      y: 0,
+      z: options.z || 0,
+    },
+    ttid: options.ttid || getRandomInt(1, 256),
+    distributions: {
+      age: [
+        /* eslint-disable max-len */
+        1.52513575812918e-5,
+        3.29484573740046e-5,
+        7.57892921683379e-5,
+        0.000167395453900099,
+        0.000344530068105087,
+        0.000667285465169698,
+        0.00123366352636367,
+        0.00207376084290445,
+        0.00311188749037683,
+        0.00429821806028485,
+        0.00562080414965749,
+        0.00719967763870955,
+        0.00919680669903755,
+        0.0118548655882478,
+        0.0155493542551994,
+        0.0203409362584352,
+        0.0259054154157639,
+        0.0314053781330585,
+        0.036177221685648,
+        0.0399368517100811,
+        0.0431549027562141,
+        0.0464486889541149,
+        0.0494710467755795,
+        0.0516735427081585,
+        0.0515337400138378,
+        0.0486019663512707,
+        0.0438462793827057,
+        0.0393034778535366,
+        0.0361261069774628,
+        0.0346308648586273,
+        0.0343437641859055,
+        0.034614410251379,
+        0.0347215309739113,
+        0.0337035432457924,
+        0.0316635780036449,
+        0.0288677662611008,
+        0.0259705595672131,
+        0.0231219734996557,
+        0.0203095134347677,
+        0.0174051597714424,
+        0.0145441647619009,
+        0.0116875432431698,
+        0.00895108189433813,
+        0.00652983970940113,
+        0.00454325648024678,
+        0.00303546176292002,
+        0.00197855522856116,
+        0.00129039806779474,
+        0.000858348445035517,
+        0.000586328154895455,
+        0.000409957923693582,
+        0.000289480754872784,
+        0.00020322397176642,
+        0.000139032184961252,
+        9.114889689954e-5,
+        5.66798735235352e-5,
+        3.37725687131751e-5,
+        1.95723478100263e-5,
+        1.12074567368836e-5,
+        6.49256253382191e-6,
+        3.88039143217611e-6,
+        2.44097009272082e-6,
+        1.68366830166633e-6,
+        1.26140650991147e-6,
+        9.88303327176254e-7,
+        7.87912085797871e-7,
+        6.19182685568376e-7,
+        4.8185165724135e-7,
+        3.64412755970989e-7,
+        2.58912194794902e-7,
+        1.81219576234071e-7,
+        1.3009683641485e-7,
+        1.00315880047219e-7,
+        8.29274355851339e-8,
+        7.28320586063091e-8,
+        6.6451534053158e-8,
+        6.24182163733167e-8,
+        5.58919914794842e-8,
+        4.61384281891242e-8,
+        3.29503109242069e-8,
+        2.03879011451136e-8,
+        1.22948247138766e-8,
+        7.86984255540801e-9,
+        5.85400350416876e-9,
+        5.2339346190422e-9,
+        5.19278309241145e-9,
+        5.31772714751355e-9,
+        5.430071947643e-9,
+        5.65056534895803e-9,
+        6.36488728389395e-9,
+        8.07834066307578e-9,
+        1.0945211847968e-8,
+        1.4646510670957e-8,
+        1.92556584011072e-8,
+        2.64477879596825e-8,
+        4.03297910622769e-8,
+        6.3962893648295e-8,
+        9.11790891677811e-8,
+        1.09187212160577e-7,
+        1.14130699557791e-7,
+        0.0,
+        /* eslint-enable max-len */
+      ],
+      gender: {
+        female: 0.00121375045273453,
+        male: 0.998786270618439,
+      },
+    },
+    expected_values: {
+      age,
+      gender,
+    },
+    local_timestamp: Date.now(),
+    poi: 2,
+    record_type: 'person',
+    rolling_expected_values: {
+      age,
+      gender,
+    },
+    recognition: options.name ? { name: options.name } : undefined,
+  };
+  return {
+    subject: RPCResponseSubject.PersonUpdate,
+    data: person,
+  };
+}

--- a/src/poi/test-utils/messages/PersonsAliveMessageGenerate.ts
+++ b/src/poi/test-utils/messages/PersonsAliveMessageGenerate.ts
@@ -1,0 +1,22 @@
+import { PersonsAliveMessage } from '../../../messages/persons-alive/PersonsAliveMessage';
+import { MessageFactory } from '../../../messages/MessageFactory';
+import { RPCResponseSubject } from '../../../constants/Constants';
+
+/**
+ * Generates a PersonsAliveMessage instance
+ * @param {string[]} ids list of person id
+ * @param {number} timestamp optional timestamp
+ * @return {PersonsAliveMessage} message
+ */
+export function generatePersonsAliveMessage(
+  ids: string[] = [],
+  timestamp: number = Date.now()
+): PersonsAliveMessage {
+  return MessageFactory.parse({
+    subject: RPCResponseSubject.PersonsAlive,
+    data: {
+      person_ids: ids,
+      local_timestamp: timestamp,
+    },
+  }) as PersonsAliveMessage;
+}

--- a/src/poi/test-utils/messages/SkeletonMessageGenerate.ts
+++ b/src/poi/test-utils/messages/SkeletonMessageGenerate.ts
@@ -1,0 +1,60 @@
+import { SkeletonMessage } from '../../../messages/skeleton/SkeletonMessage';
+import { MessageFactory } from '../../../messages/MessageFactory';
+import { getRandomInt } from '../common';
+import { Skeleton } from '../../../model/skeleton/Skeleton';
+import { indices } from '../../../model/person-attributes/PersonAttributes';
+import { BinaryType } from '../../../types';
+
+export interface BinaryOptions {
+  age?: number;
+  gender?: string;
+  ttid?: number;
+}
+
+/**
+ * Generates the data set of one single person
+ * @param {BinaryOptions} options
+ * @return {number[]}
+ */
+function generateSinglePersonBinaryData(options: BinaryOptions = {}): number[] {
+  const data = new Array(209);
+  for (let i = 0; i < 211; i++) {
+    if (i === Skeleton.bytesLength() && options.age) {
+      data[i] = options.age;
+      continue;
+    }
+    if (i === Skeleton.bytesLength() + 21 && options.ttid) {
+      data[i] = options.ttid;
+      continue;
+    }
+    if (i === Skeleton.bytesLength() + indices.male && options.gender) {
+      data[i] = options.gender === 'male' ? 0.9 : 0.1;
+      continue;
+    }
+    const indicesValues = Object.values(indices);
+    if (indicesValues.includes(i - Skeleton.bytesLength())) {
+      data[i] = getRandomInt(0, 101);
+      continue;
+    }
+
+    data[i] = getRandomInt(0, 256);
+  }
+  return data;
+}
+
+/**
+ * Generates a SkeletonMessage instance containing multiple persons
+ * @param {BinaryOptions[]} options to create the persons
+ * @return {SkeletonMessage} message
+ */
+export function generateSkeletonMessage(options: BinaryOptions[] = []): SkeletonMessage {
+  const data = options.reduce(
+    (acc: number[], curr: BinaryOptions) => {
+      return acc.concat(generateSinglePersonBinaryData(curr));
+    },
+    [0, options.length]
+  );
+
+  const binaryMessageEvent = { type: BinaryType.SKELETON, data: new Uint8Array(data) };
+  return MessageFactory.parse(binaryMessageEvent) as SkeletonMessage;
+}

--- a/src/rpc/RPCService.ts
+++ b/src/rpc/RPCService.ts
@@ -1,7 +1,5 @@
 import { Observable } from 'rxjs';
 
-export const RPCServiceType = Symbol.for('RPCServiceType');
-
 /**
  * Abstraction of the RPC service implementations
  */


### PR DESCRIPTION
~This destination branch of this PR is incorrect. I will move it to **development** once https://github.com/advertima/io/pull/11 is merged.~

**Note**: you should check the PR commit by commit.

This PR does the following:

- bump the version to `0.4.0` ~and remove the classes (`IOService`, `EventMonitor`, etc) that won't be used in the final implementation of the product engine. **This is a breaking change**, the applications that still need these classes should use `^0.3.0`~.
- Import the logic from @advertima/js-libs to add the Skeleton abstraction to the `PersonDetection` model. Now the `POISnapshot` contains a list of persons constructed with the json **and** the binary data. You can see below the old PersonDetection API and the new one. **This is a breaking change. All the previous properties are the same except `coordinates` that is removed and `metadata` that is renamed `recognition`.**

**API 0.3.x**

![0 3 xapi](https://user-images.githubusercontent.com/10107323/47926047-e5c7da80-debf-11e8-9cd9-9d0880d466d2.png)

**API 0.4.x**
![0 4 xapi](https://user-images.githubusercontent.com/10107323/47926065-f7a97d80-debf-11e8-9c1e-ea084eb513fd.png)


In a follow-up PR, I will provide a `serialize` method in the `POISnapshot` class, so that we can "serialize" the getter properties to object properties before encoding the object with _msgpack_. Without this step, all the getter properties will be _lost_ during the encoding phase.
