### PR TITLE
PEDGE-192: Removed throttling fixed record not emitted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/poi/OldPOIMonitor.ts
+++ b/src/poi/OldPOIMonitor.ts
@@ -1,8 +1,6 @@
 import { BehaviorSubject } from 'rxjs';
 import { Observer } from 'rxjs';
 import { Subscription } from 'rxjs';
-import { interval } from 'rxjs';
-import { throttle } from 'rxjs/operators';
 import { Message } from '../messages/Message';
 import { PersonsAliveMessage } from '../messages/persons-alive/PersonsAliveMessage';
 import { IncomingStream } from '../incoming-stream/IncomingStream';
@@ -91,7 +89,7 @@ export class OldPOIMonitor {
    * so consumers can unsubscribe.
    */
   public subscribe(observer: Observer<POISnapshot>): Subscription {
-    return this.snapshots.pipe(throttle(() => interval(this.rate))).subscribe(observer);
+    return this.snapshots.subscribe(observer);
   }
 }
 


### PR DESCRIPTION
This fixes the problem were the first record in a dataset was not emitted after subscribing. Removed the throttling of the POISnapshots so they're emitted every time something has changed.