### PR TITLE
Add methods to report a start and end event

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,6 @@ io.depthmapStreamMessages().subscribe(msg => ...);
 
 io.getSnapshots().subscribe(snapshot => ...);
 
+io.reportStartPlayout(33);
+io.reportEndPlayout(33);
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/constants/Constants.ts
+++ b/src/constants/Constants.ts
@@ -2,11 +2,6 @@ export enum RPCRecordType {
   ContentEvent = 'content_event',
 }
 
-export enum RPCContentEvent {
-  Start = 'start',
-  End = 'end',
-}
-
 export enum RPCFunction {
   Analytics = 'analytics',
   Download = 'download',

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -7,6 +7,8 @@ import { TecRPCService } from '../rpc/TecRPCService';
 import { RPCService } from '../rpc/RPCService';
 import { POIMonitor } from '../poi/POIMonitor';
 import { POISnapshot } from '../poi/POISnapshot';
+import { PlayoutEventService } from '../playout-event/PlayoutEventService';
+import { StartEvent, EndEvent } from '../playout-event/PlayoutEvent';
 import { BinaryMessageEvent, BinaryType } from '../types';
 
 export interface IOOptions {
@@ -29,6 +31,7 @@ export class IO {
   private incomingMessageService: IncomingMessageService;
   private rpcService: RPCService;
   private poiMonitor: POIMonitor;
+  private playoutEventService: PlayoutEventService;
 
   private canvasOptions: BinaryOptions = { width: 1920, height: 1080 };
   private imageOptions: BinaryOptions = { width: 100, height: 100 };
@@ -42,6 +45,33 @@ export class IO {
     this.incomingMessageService = new TecSDKService(this.connection);
     this.rpcService = new TecRPCService(this.connection, this.incomingMessageService);
     this.poiMonitor = new POIMonitor(this.incomingMessageService);
+    this.playoutEventService = new PlayoutEventService(this.poiMonitor);
+  }
+
+  /**
+   * Reports that a content started playing
+   * This will affect the POISnapshot
+   * @param {string} id of the content
+   */
+  public reportStartPlayout(id: string): void {
+    if (!id || typeof id !== 'string') {
+      return;
+    }
+    const startEvent = new StartEvent(id);
+    this.playoutEventService.forwardPlayoutEvent(startEvent);
+  }
+
+  /**
+   * Reports that a content started playing
+   * This will affect the POISnapshot
+   * @param {string} id of the content
+   */
+  public reportEndPlayout(id: string): void {
+    if (!id || typeof id !== 'string') {
+      return;
+    }
+    const endEvent = new EndEvent(id);
+    this.playoutEventService.forwardPlayoutEvent(endEvent);
   }
 
   /**

--- a/src/model/person-detection/PersonDetection.ts
+++ b/src/model/person-detection/PersonDetection.ts
@@ -239,7 +239,7 @@ export class PersonDetection {
    * @param {PersonDetectionMessage} json data
    */
   public updateFromJson(json: PersonDetectionMessage): void {
-    if (this.personId !== undefined && this.personId != json.personId) {
+    if (this.personId && this.personId !== json.personId) {
       throw new Error('Precondition failed, changing person_id.');
     }
     this.json = json;

--- a/src/playout-event/PlayoutEvent.ts
+++ b/src/playout-event/PlayoutEvent.ts
@@ -1,7 +1,7 @@
 /**
  * Represents a content event
  */
-export class ContentEvent {
+export class PlayoutEvent {
   /**
    * @param {string} name of the content event
    * @param {string} contentId if of the rule
@@ -18,7 +18,7 @@ export class ContentEvent {
 /**
  * Represents a start event
  */
-export class StartEvent extends ContentEvent {
+export class StartEvent extends PlayoutEvent {
   /**
    * @param {string} contentId
    */
@@ -30,7 +30,7 @@ export class StartEvent extends ContentEvent {
 /**
  * Represents an end event
  */
-export class EndEvent extends ContentEvent {
+export class EndEvent extends PlayoutEvent {
   /**
    * @param {string} contentId
    */

--- a/src/playout-event/PlayoutEventService.ts
+++ b/src/playout-event/PlayoutEventService.ts
@@ -1,0 +1,52 @@
+import { PlayoutEvent, StartEvent, EndEvent } from './PlayoutEvent';
+import { POIMonitor } from '../poi/POIMonitor';
+import { PersonDetection } from '../model/person-detection/PersonDetection';
+import { RPCRecordType } from '../constants/Constants';
+import { MessageFactory } from '../messages/MessageFactory';
+
+/**
+ * Handles the start/end event reports
+ */
+export class PlayoutEventService {
+  private lastContentEvent: PlayoutEvent;
+
+  /**
+   * Insantiates the PlayoutEventService
+   */
+  constructor(private poiMonitor: POIMonitor) {}
+
+  /**
+   * Forwards the content event to the POI
+   * @param {ContentEvent} event content event
+   */
+  public forwardPlayoutEvent(event: PlayoutEvent): void {
+    // Generate end event if it has not been reported
+    if (this.lastContentEvent instanceof StartEvent && event instanceof StartEvent) {
+      this.forwardPlayoutEvent(new EndEvent(this.lastContentEvent.contentId));
+      // Generate start event if it has not been reported
+    } else if (this.lastContentEvent instanceof EndEvent && event instanceof EndEvent) {
+      this.forwardPlayoutEvent(new StartEvent(this.lastContentEvent.contentId));
+    }
+
+    // Attach the list of persons ids from the PoIMonitor
+    const personList = Array.from(
+      this.poiMonitor
+        .getSnapshot()
+        .getPersons()
+        .values()
+    );
+    event.persons = personList.map((p: PersonDetection) => p.personPutId);
+
+    // Store last event
+    this.lastContentEvent = event;
+
+    this.poiMonitor.emitMessage(
+      MessageFactory.parse({
+        name: event.name,
+        record_type: RPCRecordType.ContentEvent,
+        content_id: event.contentId,
+        person_put_ids: event.persons,
+      })
+    );
+  }
+}

--- a/src/poi/POIMonitor.ts
+++ b/src/poi/POIMonitor.ts
@@ -58,7 +58,7 @@ export class POIMonitor {
    *
    * @param {Message} message the message sent by the POI.
    */
-  public emitSnapshot(message: Message): void {
+  public emitMessage(message: Message): void {
     this.getSnapshot().update(message);
     if (message instanceof PersonsAliveMessage) {
       if (this.isActive) {
@@ -123,7 +123,7 @@ class MessageObserver implements Observer<Message> {
    * @param {Message} m the received message.
    */
   public next(m: Message): void {
-    this.poiMonitor.emitSnapshot(m);
+    this.poiMonitor.emitMessage(m);
   }
 
   /**


### PR DESCRIPTION
Any user of `IO` can report a start/end event. This will automatically update the `POISnapshot`