### PR TITLE
Fix/add option not to start monitor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/connection/stream/Stream.ts
+++ b/src/connection/stream/Stream.ts
@@ -81,6 +81,8 @@ abstract class Stream {
    * Closes the websocket connection
    */
   public close(): void {
+    // onclose is the user callback. But we don't want to call _onclose
+    this.ws.onclose = this.onclose;
     this.ws.close();
     clearTimeout(this.retryId);
   }

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -16,6 +16,7 @@ export interface IOOptions {
   jsonHost?: string; // host for the json stream connection
   binaryPort?: number; // port for the binary stream connection
   binaryHost?: string; // host for the json stream connection
+  noSnapshot?: boolean; // set true if you don't want the POISnapshot to be built
 }
 
 interface BinaryOptions {
@@ -81,7 +82,9 @@ export class IO {
   public connect(options: IOOptions): void {
     this.connection.open(options);
     this.updateBinaryOptions();
-    this.poiMonitor.start();
+    if (!options.noSnapshot) {
+      this.poiMonitor.start();
+    }
   }
 
   /**


### PR DESCRIPTION
This PR

- adds the possibility to not start the POIMonitor when you only need the raw stream. Example: `io.connect({noSnapshot: true})`
- fixes a bug when the stream was reconnecting even when the connection was automatically closed with `io.disconnect()`