### PR TITLE
Task/pedge 218 add tojson methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,15 @@ io.connect({
 io.rpc('analytics', data);
 io.rpc('download', data).subscribe(res => ...);
 
+io.updateResolutions({
+  canvas: {width: 320, width: 480},
+  image: {width: 100, width: 100},
+  thumbnail: {width: 1920, width: 1080},
+})
+
 io.jsonStreamMessages().subscribe(msg => ...);
 io.skeletonStreamMessages(1920, 1080).subscribe(msg => ...);
-io.imageStreamMessages(320, 480).subscribe(msg => ...);
+io.imageStreamMessages().subscribe(msg => ...);
 io.thumbnailStreamMessages(100, 100).subscribe(msg => ...);
 io.heatmapStreamMessages().subscribe(msg => ...);
 io.depthmapStreamMessages().subscribe(msg => ...);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/connection/stream/Stream.ts
+++ b/src/connection/stream/Stream.ts
@@ -1,4 +1,5 @@
 import { Utils } from '../../utils/Utils';
+import { BinaryDataType } from '../../constants/Constants';
 import { decode } from 'msgpack-lite';
 import './Socket';
 
@@ -175,14 +176,6 @@ abstract class Stream {
       this.ws.send(msg);
     }
   }
-}
-
-export enum BinaryDataType {
-  TYPE_IMAGE = 1,
-  TYPE_SKELETON = 2,
-  TYPE_THUMBNAIL = 3,
-  TYPE_HEATMAP = 4,
-  TYPE_DEPTHMAP = 5,
 }
 
 /**

--- a/src/constants/Constants.ts
+++ b/src/constants/Constants.ts
@@ -12,3 +12,11 @@ export enum RPCResponseSubject {
   PersonUpdate = 'person_update',
   PersonsAlive = 'persons_alive',
 }
+
+export enum BinaryDataType {
+  TYPE_IMAGE = 1,
+  TYPE_SKELETON = 2,
+  TYPE_THUMBNAIL = 3,
+  TYPE_HEATMAP = 4,
+  TYPE_DEPTHMAP = 5,
+}

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -81,7 +81,7 @@ export class IO {
    */
   public connect(options: IOOptions): void {
     this.connection.open(options);
-    this.updateBinaryOptions();
+    this.updateResolutions();
     if (!options.noSnapshot) {
       this.poiMonitor.start();
     }
@@ -109,9 +109,9 @@ export class IO {
    * @param {number} height of the camera canvas
    * @return {Observable<BinaryMessageEvent>}
    */
-  public imageStreamMessages(width: number, height: number): Observable<BinaryMessageEvent> {
+  public imageStreamMessages(width?: number, height?: number): Observable<BinaryMessageEvent> {
     this.imageOptions = isNaN(width) || isNaN(height) ? this.imageOptions : { width, height };
-    this.updateBinaryOptions();
+    this.updateResolutions();
     return this.incomingMessageService.binaryStreamMessages(BinaryType.IMAGE);
   }
 
@@ -121,9 +121,9 @@ export class IO {
    * @param {number} height of the skeleton canvas
    * @return {Observable<BinaryMessageEvent>}
    */
-  public skeletonStreamMessages(width: number, height: number): Observable<BinaryMessageEvent> {
+  public skeletonStreamMessages(width?: number, height?: number): Observable<BinaryMessageEvent> {
     this.canvasOptions = isNaN(width) || isNaN(height) ? this.canvasOptions : { width, height };
-    this.updateBinaryOptions();
+    this.updateResolutions();
     return this.incomingMessageService.binaryStreamMessages(BinaryType.SKELETON);
   }
 
@@ -133,10 +133,10 @@ export class IO {
    * @param {number} height of the thumbnail canvas
    * @return {Observable<BinaryMessageEvent>}
    */
-  public thumbnailStreamMessages(width: number, height: number): Observable<BinaryMessageEvent> {
+  public thumbnailStreamMessages(width?: number, height?: number): Observable<BinaryMessageEvent> {
     this.thumbnailOptions =
       isNaN(width) || isNaN(height) ? this.thumbnailOptions : { width, height };
-    this.updateBinaryOptions();
+    this.updateResolutions();
     return this.incomingMessageService.binaryStreamMessages(BinaryType.THUMBNAIL);
   }
 
@@ -177,12 +177,15 @@ export class IO {
   /**
    * Send the camera, skeleton and thumbnail options
    * via RPC
+   * @param {Object} options width and height of the camera, image and thumbnail canvas
    */
-  private updateBinaryOptions(): void {
+  public updateResolutions(
+    options: { canvas?: BinaryOptions; image?: BinaryOptions; thumbnail?: BinaryOptions } = {}
+  ): void {
     this.connection.sendBinaryStream({
-      canvas: this.canvasOptions,
-      image: this.imageOptions,
-      thumbnail: this.thumbnailOptions,
+      canvas: options.canvas || this.canvasOptions,
+      image: options.image || this.imageOptions,
+      thumbnail: options.thumbnail || this.thumbnailOptions,
     });
   }
 }

--- a/src/model/person-detection/PersonDetection.ts
+++ b/src/model/person-detection/PersonDetection.ts
@@ -269,4 +269,35 @@ export class PersonDetection {
 
     return person;
   }
+
+  /**
+   * Creates a static object from the instance properties and dynamic getters
+   * @return {Object} static object that has the same properties as the instance
+   */
+  public toJSON(): Object {
+    return {
+      localTimestamp: this.localTimestamp,
+      poi: this.poi,
+      name: this.name,
+      gender: this.gender,
+      personId: this.personId,
+      personPutId: this.personPutId,
+      recognition: this.recognition,
+      isLookingAtScreen: this.isLookingAtScreen,
+      cameraId: this.cameraId,
+      u: this.u,
+      v: this.v,
+      z: this.z,
+      isMale: this.isMale,
+      isFemale: this.isFemale,
+      age: this.age,
+      likelihoodMale: this.likelihoodMale,
+      isRecognized: this.isRecognized,
+      ttid: this.ttid,
+      headpose: this.headpose,
+      onlyTtid: this.onlyTtid,
+      robustFaceAttributes: this.robustFaceAttributes,
+      allFaceAttributes: this.allFaceAttributes,
+    };
+  }
 }

--- a/src/poi/POISnapshot.ts
+++ b/src/poi/POISnapshot.ts
@@ -103,6 +103,22 @@ export class POISnapshot {
   }
 
   /**
+   * Creates an object from the properties
+   * of the POISnapshot instance
+   * @return {Object}
+   */
+  public toJSON(): Object {
+    const persons = {};
+    this.persons.forEach((person, id) => (persons[id] = person.toJSON()));
+    const result = {
+      content: this.content,
+      lastUpdateTimestamp: this.lastUpdateTimestamp,
+      persons,
+    };
+    return result;
+  }
+
+  /**
    * In order to create a person with valid state, we need both the json and
    * the binary data. Therefore the data has to be cached until both data
    * elements are available


### PR DESCRIPTION
This PR adds 

- a `toJSON()` method on the `POISnapshot` and `PersonDetection`. Since the `PersonDetection` has a lot of computed properties, we need to execute this method to get a static version of the object before encoding it.

- expose a public `updateResolutions` method so that the user can set all the resolutions in once. Consequently, the `width` and `height` parameters on the observable functions are now optional