### PR TITLE
Check if the stream has been subscribed to before unsubscribing on disconnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/poi/POIMonitor.ts
+++ b/src/poi/POIMonitor.ts
@@ -75,7 +75,9 @@ export class POIMonitor {
    * Marks the stream as completed.
    */
   public complete(): void {
-    this.streamSubscription.unsubscribe();
+    if (this.streamSubscription) {
+      this.streamSubscription.unsubscribe();
+    }
     this.snapshots.complete();
   }
 


### PR DESCRIPTION
Because of this PR https://github.com/advertima/io/pull/18, if you used the `noSnapshot: true` and later called `io.disconnect()`, the following error was thrown.
![screen shot 2018-11-13 at 15 14 15](https://user-images.githubusercontent.com/10107323/48418978-0eb95c80-e757-11e8-8051-319863d2ec2f.png)
