### PR TITLE
Dev/pedge 239 add distance and snapshot decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The @advertima/io type definitions are included in the npm package.
 ## Basics
 
 ```js
-import {IO, StartEvent, EndEvent} from '@advertima/io';
+import {IO, StartEvent, EndEvent, POISnapshot} from '@advertima/io';
 
 const io = new IO(); // optionally you can pass a WSConnection instance. By default it will use an instance of TecWSConnection
 
@@ -47,6 +47,9 @@ io.getSnapshots().subscribe(snapshot => ...);
 
 io.reportPlayoutEvent(new StartEvent(33, 8, '33e17c5c-214f', 1542360299788));
 io.reportPlayoutEvent(new EndEvent(33, 8, '33e17c5c-214f', 1542360500504));
+
+// Decode binary snapshot
+const snapshot = POISnapshot.decode(someBinaryData);
 ```
 
 ## Test Utils

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.4.10",
+  "version": "0.4.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/model/person-detection/PersonDetection.ts
+++ b/src/model/person-detection/PersonDetection.ts
@@ -36,6 +36,17 @@ export class PersonDetection {
   }
 
   /**
+   * Distance between the person and the camera
+   * @return {number}
+   */
+  get distance(): number {
+    const u = this.u;
+    const v = this.v;
+    const z = this.z;
+    return Math.sqrt(u * u + v * v + z * z);
+  }
+
+  /**
    * Returns the name of the recognised person
    * or null if the person is not recognised
    * @return {string} the name of the recognised person

--- a/src/model/person-detection/PersonDetection.ts
+++ b/src/model/person-detection/PersonDetection.ts
@@ -277,6 +277,10 @@ export class PersonDetection {
     person.skeleton = cache.skeleton;
     person.personAttributes = cache.personAttributes;
 
+    if (person.json.localTimestamp) {
+      person.updated = person.json.localTimestamp;
+    }
+
     return person;
   }
 
@@ -320,6 +324,9 @@ export class PersonDetection {
       onlyEyeglasses: this.onlyEyeglasses,
       robustFaceAttributes: this.robustFaceAttributes,
       allFaceAttributes: this.allFaceAttributes,
+      json: this.json,
+      personAttributes: this.personAttributes,
+      dataProvider: this.skeleton.getDataProvider().getData(),
     };
   }
 }

--- a/src/model/skeleton/Skeleton.ts
+++ b/src/model/skeleton/Skeleton.ts
@@ -285,6 +285,14 @@ export class Skeleton {
     // 18 joints with x_2d, y_2d, x_3d, y_3d, z_3d encoded with 2 bytes each
     return 18 * 5 * 2;
   }
+
+  /**
+   * Returns the internal data provider
+   * @return {SkeletonBinaryDataProvider}
+   */
+  public getDataProvider(): SkeletonBinaryDataProvider {
+    return this.dataProvider;
+  }
 }
 
 /**
@@ -306,6 +314,14 @@ export class SkeletonBinaryDataProvider {
       );
     }
     this.data = data;
+  }
+
+  /**
+   * Returns the internal binary data
+   * @return {Uint8Array}
+   */
+  public getData(): Uint8Array {
+    return this.data;
   }
 
   /* eslint-disable require-jsdoc */

--- a/src/poi/test-utils/poi/POISnapshotGenerator.ts
+++ b/src/poi/test-utils/poi/POISnapshotGenerator.ts
@@ -16,6 +16,12 @@ export class POISnapshotGenerator {
    * @return {POISnapshot}
    */
   static generate(options: any[] = [], from: POISnapshot = new POISnapshot()): POISnapshot {
+    if (!Array.isArray(options)) {
+      throw new Error(
+        'POISnapshotGenerator first parameter should be a list of PersonOptions|ContentOptions'
+      );
+    }
+
     const snapshot = from;
 
     const personOptions: PersonOptions[] = options.filter(option => option.hasOwnProperty('ttid'));


### PR DESCRIPTION
This PR adds

- a decoder that creates a `POISnapshot` instance from encoded binary data: `POISnapshot.decode(data)`. More infos in the implementation and unit test
- add the `distance` getter in the `PersonDetection` model so that we have a unified way of calculating the distance (instead of each app implementation its own calculation)