### PR TITLE
Fix/pedge 147 emit mock detections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/poi/POIMonitor.spec.ts
+++ b/src/poi/POIMonitor.spec.ts
@@ -1,0 +1,150 @@
+import test from 'ava';
+import { Observable, Subject } from 'rxjs';
+import { IncomingMessageService } from '../incoming-message/IncomingMessageService';
+import { BinaryMessageEvent, BinaryType } from '../types';
+import {
+  POIMonitor,
+  INACTIVE_STREAM_THRESHOLD,
+  INACTIVE_STREAM_MESSAGE_INTERVAL,
+} from './POIMonitor';
+import { POISnapshot, MAX_RECENT_TIME } from './POISnapshot';
+import { generateSinglePersonUpdateData, generateSinglePersonBinaryData } from './test-utils';
+import { RPCResponseSubject } from '../constants/Constants';
+
+test.cb(
+  `should start emitting empty detections every 200 milliseconds if the stream
+  is not sending anything and switch back to the stream when it is back online`,
+  t => {
+    const jsonSubject = new Subject();
+    const binarySubject = new Subject<BinaryMessageEvent>();
+
+    /* eslint-disable require-jsdoc */
+    class MockMessageService implements IncomingMessageService {
+      jsonStreamMessages(): Observable<any> {
+        return jsonSubject.asObservable();
+      }
+
+      binaryStreamMessages(type?: BinaryType): Observable<BinaryMessageEvent> {
+        return binarySubject.asObservable();
+      }
+    }
+    /* eslint-enable require-jsdoc */
+
+    const poiMonitor = new POIMonitor(new MockMessageService());
+
+    const emittedSnapshots: POISnapshot[] = [];
+    poiMonitor.getPOISnapshotObservable().subscribe(snapshot => {
+      emittedSnapshots.push(snapshot);
+    });
+
+    poiMonitor.start();
+
+    // should emit detections every 200 ms after 2 seconds of no detections
+    const n = 5;
+    setTimeout(() => {
+      t.is(emittedSnapshots.length, n);
+      t.is(poiMonitor['isActive'], false);
+      emittedSnapshots.forEach(snapshot => {
+        t.is(snapshot.getPersons().size, 0);
+        t.is(snapshot.getContent(), undefined);
+      });
+
+      // POI is back
+      const personId = 'rcyb48vg-4eha';
+      const ttid = 89;
+      jsonSubject.next({
+        data: generateSinglePersonUpdateData({ ttid, personId }),
+        subject: RPCResponseSubject.PersonUpdate,
+      });
+      binarySubject.next({
+        data: new Uint8Array([0, 1, ...generateSinglePersonBinaryData({ ttid })]),
+        type: BinaryType.SKELETON,
+      });
+
+      // last snapshot should have the PersonDetection
+      const lastSnapshot = emittedSnapshots[emittedSnapshots.length - 1];
+
+      t.is(emittedSnapshots.length, n + 2);
+      t.is(lastSnapshot.getPersons().size, 1);
+      t.is(lastSnapshot.getPersons().get(personId).ttid, ttid);
+      t.is(poiMonitor['isActive'], true);
+      t.end();
+    }, INACTIVE_STREAM_THRESHOLD + n * INACTIVE_STREAM_MESSAGE_INTERVAL);
+  }
+);
+
+test.cb(
+  `should create snapshots from the stream detections
+  and emit empty snapshots when the stream is down`,
+  t => {
+    const jsonSubject = new Subject();
+    const binarySubject = new Subject<BinaryMessageEvent>();
+
+    /* eslint-disable require-jsdoc */
+    class MockMessageService implements IncomingMessageService {
+      jsonStreamMessages(): Observable<any> {
+        return jsonSubject.asObservable();
+      }
+
+      binaryStreamMessages(type?: BinaryType): Observable<BinaryMessageEvent> {
+        return binarySubject.asObservable();
+      }
+    }
+    /* eslint-enable require-jsdoc */
+
+    const poiMonitor = new POIMonitor(new MockMessageService());
+
+    const emittedSnapshots: POISnapshot[] = [];
+    poiMonitor.getPOISnapshotObservable().subscribe(snapshot => {
+      emittedSnapshots.push(snapshot);
+    });
+
+    // Emit a person detection every 10ms
+    const personId = 'rcyb48vg-4eha';
+    const ttid = 89;
+    const detectionsInterval = setInterval(() => {
+      jsonSubject.next({
+        data: generateSinglePersonUpdateData({ ttid, personId }),
+        subject: RPCResponseSubject.PersonUpdate,
+      });
+      binarySubject.next({
+        data: new Uint8Array([0, 1, ...generateSinglePersonBinaryData({ ttid })]),
+        type: BinaryType.SKELETON,
+      });
+    }, 10);
+
+    poiMonitor.start();
+
+    setTimeout(() => {
+      // stop detections
+      clearInterval(detectionsInterval);
+      // Expect all the snapshots except the two first ones to have a person
+      // Note: the 1st snapshot will have only the json data,
+      // the POISnapshot needs json + binary to build a PersonDetection
+      t.not(emittedSnapshots.length, 0);
+      for (let i = 0; i < emittedSnapshots.length; i++) {
+        if (i === 0) {
+          t.is(emittedSnapshots[i].getPersons().size, 0);
+        } else {
+          t.is(emittedSnapshots[i].getPersons().size, 1);
+        }
+      }
+
+      const newEmittedSnapshots = [];
+      poiMonitor.getPOISnapshotObservable().subscribe(snapshot => {
+        newEmittedSnapshots.push(snapshot);
+      });
+
+      // After, the Stream detections are stopped, expect new empty snapshots emissions
+      setTimeout(() => {
+        t.not(emittedSnapshots.length, 0);
+        for (let i = 0; i < newEmittedSnapshots.length; i++) {
+          t.is(newEmittedSnapshots[i].getPersons().size, 0);
+        }
+        t.end();
+        // the timeout needs to be > MAX_RECENT_TIME, to make sure that the lost persons are cleaned
+        // (the lost persons threshold is 2 seconds)
+      }, MAX_RECENT_TIME + 500);
+    }, INACTIVE_STREAM_THRESHOLD);
+  }
+);

--- a/src/poi/POIMonitor.ts
+++ b/src/poi/POIMonitor.ts
@@ -67,8 +67,8 @@ export class POIMonitor {
         this.logger.warn('PoI is back.');
         this.isActive = true;
       }
+      this.snapshots.next(this.getPOISnapshot().clone());
     }
-    this.snapshots.next(this.getPOISnapshot().clone());
   }
 
   /**

--- a/src/poi/POIMonitor.ts
+++ b/src/poi/POIMonitor.ts
@@ -3,11 +3,17 @@ import { Observer, Observable } from 'rxjs';
 import { Subscription, merge } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Message } from '../messages/Message';
+import { SkeletonMessage } from '../messages/skeleton/SkeletonMessage';
+import { PersonDetectionMessage } from '../messages/person-detection/PersonDetectionMessage';
+import { UnknownMessage } from '../messages/unknown/UnknownMessage';
 import { MessageFactory } from '../messages/MessageFactory';
 import { PersonsAliveMessage } from '../messages/persons-alive/PersonsAliveMessage';
 import { IncomingMessageService } from '../incoming-message/IncomingMessageService';
 import { POISnapshot } from './POISnapshot';
 import { BinaryType } from '../types';
+
+export const INACTIVE_STREAM_THRESHOLD = 2000;
+export const INACTIVE_STREAM_MESSAGE_INTERVAL = 200;
 
 /**
  * Monitors a POI and informs the subscribers about
@@ -16,6 +22,7 @@ import { BinaryType } from '../types';
 export class POIMonitor {
   private isActive: boolean = true;
   private isActiveTimeout;
+  private mockMessagesInterval;
   private snapshots: BehaviorSubject<POISnapshot> = new BehaviorSubject(new POISnapshot());
   private logger = console;
   private streamSubscription: Subscription;
@@ -34,6 +41,7 @@ export class POIMonitor {
    */
   public start(): void {
     if (!this.streamSubscription || this.streamSubscription.closed) {
+      this.updateHealthTimeout();
       this.streamSubscription = merge(
         this.msgService.jsonStreamMessages(),
         this.msgService.binaryStreamMessages(BinaryType.SKELETON)
@@ -60,14 +68,22 @@ export class POIMonitor {
    */
   public emitMessage(message: Message): void {
     this.getPOISnapshot().update(message);
-    if (message instanceof PersonsAliveMessage) {
+    if (!(message instanceof UnknownMessage)) {
+      this.snapshots.next(this.getPOISnapshot().clone());
+    }
+    if (
+      message instanceof PersonsAliveMessage ||
+      message instanceof SkeletonMessage ||
+      message instanceof PersonDetectionMessage
+    ) {
       if (this.isActive) {
         this.updateHealthTimeout();
       } else {
         this.logger.warn('PoI is back.');
         this.isActive = true;
+        clearTimeout(this.isActiveTimeout);
+        clearInterval(this.mockMessagesInterval);
       }
-      this.snapshots.next(this.getPOISnapshot().clone());
     }
   }
 
@@ -78,6 +94,8 @@ export class POIMonitor {
     if (this.streamSubscription) {
       this.streamSubscription.unsubscribe();
     }
+    clearTimeout(this.isActiveTimeout);
+    clearInterval(this.mockMessagesInterval);
     this.snapshots.complete();
   }
 
@@ -89,12 +107,15 @@ export class POIMonitor {
   private updateHealthTimeout(): void {
     clearTimeout(this.isActiveTimeout);
     this.isActiveTimeout = setTimeout(() => {
+      clearInterval(this.mockMessagesInterval);
       this.isActive = false;
       this.logger.warn('PoI stopped emitting.');
-      this.getPOISnapshot().setPersons(new Map());
-      this.getPOISnapshot().update(new PersonsAliveMessage({ data: { person_ids: [] } }));
-      this.snapshots.next(this.getPOISnapshot().clone());
-    }, 2000);
+      this.mockMessagesInterval = setInterval(() => {
+        this.getPOISnapshot().setPersons(new Map());
+        this.getPOISnapshot().update(new PersonsAliveMessage({ data: { person_ids: [] } }));
+        this.snapshots.next(this.getPOISnapshot().clone());
+      }, INACTIVE_STREAM_MESSAGE_INTERVAL);
+    }, INACTIVE_STREAM_THRESHOLD);
   }
 
   /**

--- a/src/poi/POISnapshot.ts
+++ b/src/poi/POISnapshot.ts
@@ -11,7 +11,7 @@ import { Skeleton, SkeletonBinaryDataProvider, BinaryCachedData } from '../model
 
 // Maximum amount of time (in ms) between now and the last person event
 // to consider the person as recent
-const MAX_RECENT_TIME = 2000;
+export const MAX_RECENT_TIME = 2000;
 
 /**
  * Represents what is happening at a POI at a given point in time.

--- a/src/poi/test-utils/messages/PersonDetectionMessageGenerator.ts
+++ b/src/poi/test-utils/messages/PersonDetectionMessageGenerator.ts
@@ -12,176 +12,184 @@ export class PersonDetectionMessageGenerator {
    * @return {PersonDetectionMessage} person detection message
    */
   static generate(options: PersonOptions): PersonDetectionMessage {
-    const data = {
-      person_id:
-        options.personId ||
-        `_${Math.random()
-          .toString(36)
-          .substr(2, 9)}`,
-      person_put_id:
-        options.personPutId ||
-        `_${Math.random()
-          .toString(36)
-          .substr(2, 9)}`,
-      behavior: {
-        body: {
-          left_arm: 0,
-          right_arm: 0,
-          raising_left_hand: 0,
-          raising_right_hand: 0,
-        },
-        head: {
-          looking_at_screen: options.lookingAtScreen === true ? 0 : 0.1,
-        },
-      },
-      camera_id: options.cameraId,
-      coordinates: {
-        x: options.u || 0,
-        y: options.v || 0,
-        z: options.z || 0,
-      },
-      ttid: options.ttid,
-      distributions: {
-        age: [
-          /* eslint-disable max-len */
-          1.52513575812918e-5,
-          3.29484573740046e-5,
-          7.57892921683379e-5,
-          0.000167395453900099,
-          0.000344530068105087,
-          0.000667285465169698,
-          0.00123366352636367,
-          0.00207376084290445,
-          0.00311188749037683,
-          0.00429821806028485,
-          0.00562080414965749,
-          0.00719967763870955,
-          0.00919680669903755,
-          0.0118548655882478,
-          0.0155493542551994,
-          0.0203409362584352,
-          0.0259054154157639,
-          0.0314053781330585,
-          0.036177221685648,
-          0.0399368517100811,
-          0.0431549027562141,
-          0.0464486889541149,
-          0.0494710467755795,
-          0.0516735427081585,
-          0.0515337400138378,
-          0.0486019663512707,
-          0.0438462793827057,
-          0.0393034778535366,
-          0.0361261069774628,
-          0.0346308648586273,
-          0.0343437641859055,
-          0.034614410251379,
-          0.0347215309739113,
-          0.0337035432457924,
-          0.0316635780036449,
-          0.0288677662611008,
-          0.0259705595672131,
-          0.0231219734996557,
-          0.0203095134347677,
-          0.0174051597714424,
-          0.0145441647619009,
-          0.0116875432431698,
-          0.00895108189433813,
-          0.00652983970940113,
-          0.00454325648024678,
-          0.00303546176292002,
-          0.00197855522856116,
-          0.00129039806779474,
-          0.000858348445035517,
-          0.000586328154895455,
-          0.000409957923693582,
-          0.000289480754872784,
-          0.00020322397176642,
-          0.000139032184961252,
-          9.114889689954e-5,
-          5.66798735235352e-5,
-          3.37725687131751e-5,
-          1.95723478100263e-5,
-          1.12074567368836e-5,
-          6.49256253382191e-6,
-          3.88039143217611e-6,
-          2.44097009272082e-6,
-          1.68366830166633e-6,
-          1.26140650991147e-6,
-          9.88303327176254e-7,
-          7.87912085797871e-7,
-          6.19182685568376e-7,
-          4.8185165724135e-7,
-          3.64412755970989e-7,
-          2.58912194794902e-7,
-          1.81219576234071e-7,
-          1.3009683641485e-7,
-          1.00315880047219e-7,
-          8.29274355851339e-8,
-          7.28320586063091e-8,
-          6.6451534053158e-8,
-          6.24182163733167e-8,
-          5.58919914794842e-8,
-          4.61384281891242e-8,
-          3.29503109242069e-8,
-          2.03879011451136e-8,
-          1.22948247138766e-8,
-          7.86984255540801e-9,
-          5.85400350416876e-9,
-          5.2339346190422e-9,
-          5.19278309241145e-9,
-          5.31772714751355e-9,
-          5.430071947643e-9,
-          5.65056534895803e-9,
-          6.36488728389395e-9,
-          8.07834066307578e-9,
-          1.0945211847968e-8,
-          1.4646510670957e-8,
-          1.92556584011072e-8,
-          2.64477879596825e-8,
-          4.03297910622769e-8,
-          6.3962893648295e-8,
-          9.11790891677811e-8,
-          1.09187212160577e-7,
-          1.14130699557791e-7,
-          0.0,
-          /* eslint-enable max-len */
-        ],
-        gender: {
-          female: 0.00121375045273453,
-          male: 0.998786270618439,
-        },
-      },
-      expected_values: {
-        age: options.age,
-        gender: options.gender,
-      },
-      local_timestamp: options.localTimestamp || Date.now(),
-      poi: options.poi,
-      record_type: 'person',
-      rolling_expected_values: {
-        age: options.age || 0,
-        gender: options.gender || 'male',
-      },
-      recognition: options.name ? { name: options.name } : undefined,
-      best_face_embedding: undefined,
-    };
-
-    if (options.generateEmbeddings) {
-      const embeddings: Array<number> = [];
-      const embeddingsSize = 256;
-      const maxEmbeddingValue = 255;
-
-      for (let i = 0; i < embeddingsSize; i++) {
-        embeddings.push(Math.floor((Math.random() * maxEmbeddingValue) + 1));
-      }
-
-      data.best_face_embedding = embeddings;
-    }
-
     return MessageFactory.parse({
       subject: 'person_update',
-      data,
+      data: generateSinglePersonUpdateData(options),
     }) as PersonDetectionMessage;
   }
+}
+
+/**
+ * Creates the person_update json object based on the options
+ * @param {PersonOptions} options
+ * @return {Object}
+ */
+export function generateSinglePersonUpdateData(options: PersonOptions): Object {
+  const data = {
+    person_id:
+      options.personId ||
+      `_${Math.random()
+        .toString(36)
+        .substr(2, 9)}`,
+    person_put_id:
+      options.personPutId ||
+      `_${Math.random()
+        .toString(36)
+        .substr(2, 9)}`,
+    behavior: {
+      body: {
+        left_arm: 0,
+        right_arm: 0,
+        raising_left_hand: 0,
+        raising_right_hand: 0,
+      },
+      head: {
+        looking_at_screen: options.lookingAtScreen === true ? 0 : 0.1,
+      },
+    },
+    camera_id: options.cameraId,
+    coordinates: {
+      x: options.u || 0,
+      y: options.v || 0,
+      z: options.z || 0,
+    },
+    ttid: options.ttid,
+    distributions: {
+      age: [
+        /* eslint-disable max-len */
+        1.52513575812918e-5,
+        3.29484573740046e-5,
+        7.57892921683379e-5,
+        0.000167395453900099,
+        0.000344530068105087,
+        0.000667285465169698,
+        0.00123366352636367,
+        0.00207376084290445,
+        0.00311188749037683,
+        0.00429821806028485,
+        0.00562080414965749,
+        0.00719967763870955,
+        0.00919680669903755,
+        0.0118548655882478,
+        0.0155493542551994,
+        0.0203409362584352,
+        0.0259054154157639,
+        0.0314053781330585,
+        0.036177221685648,
+        0.0399368517100811,
+        0.0431549027562141,
+        0.0464486889541149,
+        0.0494710467755795,
+        0.0516735427081585,
+        0.0515337400138378,
+        0.0486019663512707,
+        0.0438462793827057,
+        0.0393034778535366,
+        0.0361261069774628,
+        0.0346308648586273,
+        0.0343437641859055,
+        0.034614410251379,
+        0.0347215309739113,
+        0.0337035432457924,
+        0.0316635780036449,
+        0.0288677662611008,
+        0.0259705595672131,
+        0.0231219734996557,
+        0.0203095134347677,
+        0.0174051597714424,
+        0.0145441647619009,
+        0.0116875432431698,
+        0.00895108189433813,
+        0.00652983970940113,
+        0.00454325648024678,
+        0.00303546176292002,
+        0.00197855522856116,
+        0.00129039806779474,
+        0.000858348445035517,
+        0.000586328154895455,
+        0.000409957923693582,
+        0.000289480754872784,
+        0.00020322397176642,
+        0.000139032184961252,
+        9.114889689954e-5,
+        5.66798735235352e-5,
+        3.37725687131751e-5,
+        1.95723478100263e-5,
+        1.12074567368836e-5,
+        6.49256253382191e-6,
+        3.88039143217611e-6,
+        2.44097009272082e-6,
+        1.68366830166633e-6,
+        1.26140650991147e-6,
+        9.88303327176254e-7,
+        7.87912085797871e-7,
+        6.19182685568376e-7,
+        4.8185165724135e-7,
+        3.64412755970989e-7,
+        2.58912194794902e-7,
+        1.81219576234071e-7,
+        1.3009683641485e-7,
+        1.00315880047219e-7,
+        8.29274355851339e-8,
+        7.28320586063091e-8,
+        6.6451534053158e-8,
+        6.24182163733167e-8,
+        5.58919914794842e-8,
+        4.61384281891242e-8,
+        3.29503109242069e-8,
+        2.03879011451136e-8,
+        1.22948247138766e-8,
+        7.86984255540801e-9,
+        5.85400350416876e-9,
+        5.2339346190422e-9,
+        5.19278309241145e-9,
+        5.31772714751355e-9,
+        5.430071947643e-9,
+        5.65056534895803e-9,
+        6.36488728389395e-9,
+        8.07834066307578e-9,
+        1.0945211847968e-8,
+        1.4646510670957e-8,
+        1.92556584011072e-8,
+        2.64477879596825e-8,
+        4.03297910622769e-8,
+        6.3962893648295e-8,
+        9.11790891677811e-8,
+        1.09187212160577e-7,
+        1.14130699557791e-7,
+        0.0,
+        /* eslint-enable max-len */
+      ],
+      gender: {
+        female: 0.00121375045273453,
+        male: 0.998786270618439,
+      },
+    },
+    expected_values: {
+      age: options.age,
+      gender: options.gender,
+    },
+    local_timestamp: options.localTimestamp || Date.now(),
+    poi: options.poi,
+    record_type: 'person',
+    rolling_expected_values: {
+      age: options.age || 0,
+      gender: options.gender || 'male',
+    },
+    recognition: options.name ? { name: options.name } : undefined,
+    best_face_embedding: undefined,
+  };
+
+  if (options.generateEmbeddings) {
+    const embeddings: Array<number> = [];
+    const embeddingsSize = 256;
+    const maxEmbeddingValue = 255;
+
+    for (let i = 0; i < embeddingsSize; i++) {
+      embeddings.push(Math.floor(Math.random() * maxEmbeddingValue + 1));
+    }
+
+    data.best_face_embedding = embeddings;
+  }
+  return data;
 }

--- a/src/poi/test-utils/messages/SkeletonMessageGenerator.ts
+++ b/src/poi/test-utils/messages/SkeletonMessageGenerator.ts
@@ -32,7 +32,7 @@ export class SkeletonMessageGenerator {
  * @param {PersonOptions} options
  * @return {number[]}
  */
-function generateSinglePersonBinaryData(options: PersonOptions = { ttid: 1 }): number[] {
+export function generateSinglePersonBinaryData(options: PersonOptions = { ttid: 1 }): number[] {
   const data = new Array(209);
   for (let i = 0; i < 211; i++) {
     if (i === Skeleton.bytesLength() && options.age) {


### PR DESCRIPTION
This PR fixes https://jira.advertima.com/browse/PEDGE-147 on 0.5.x. I will make another fix for 0.3.x against the 0.3.x branch later.

Scenario 1:
- The `POIMonitor` already subscribed to the TEC streams and received messages
- The TEC stream stop sending messages (skeleton, persons)

Result: we already handled this case and were emitting _fake_ empty `persons_alive` messages.

Scenario 2:
- The TEC stream is broken and does not send any messages (skeleton, persons)
- After that, the `POIMonitor` subscribes to the TEC streams

Result: This scenario was not handled.

I refactored the code and made a fix so that in both case we emit a _fake_ empty `persons_alive` message until the stream is back and emits a person message (update, alive or skeleton).
