### PR TITLE
PEDGE-239: when the json stream does not emit messages before the subscription, also emit empty persons_alive messages until the stream recovers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/io-service/IOService.ts
+++ b/src/io-service/IOService.ts
@@ -13,7 +13,7 @@ export class IOService {
    * Default constructor
    */
   constructor(private incomingStream: IncomingStream, private rate?: number) {
-    this.poiMonitor = new OldPOIMonitor(this.incomingStream, this.rate);
+    this.poiMonitor = new OldPOIMonitor(this.incomingStream);
     this.eventMonitor = new EventMonitor(this.incomingStream, this.poiMonitor);
   }
 


### PR DESCRIPTION
This fix is the same as https://github.com/advertima/io/pull/30 but on the `OldPOIMonitor` class. Thus, the PR is merged to the **0.3.x** branch and the version bump is *0.3.7*.