### PR TITLE
PEDGE-234: fix parsing of person_update message to extract the face embeddings array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/messages/person-detection/PersonDetectionMessage.ts
+++ b/src/messages/person-detection/PersonDetectionMessage.ts
@@ -42,7 +42,9 @@ export class PersonDetectionMessage extends Message {
     this.lookingAtScreen = json.data.behavior.head.looking_at_screen;
     this.cameraId = json.data.camera_id;
     this.poi = json.data.poi;
-    this.faceEmbeddings = json.data.best_face_embedding;
+    if (json.data.best_face_embedding) {
+      this.faceEmbeddings = json.data.best_face_embedding.face_embeddings;
+    }
   }
 
   /**

--- a/src/messages/person-detection/PersonDetectionSchema.ts
+++ b/src/messages/person-detection/PersonDetectionSchema.ts
@@ -113,9 +113,17 @@ export const PersonDetectionSchema = {
       },
     },
     best_face_embedding: {
-      type: 'array',
-      items: {
-        type: 'number',
+      type: 'object',
+      properties: {
+        face_embeddings: {
+          type: 'array',
+          items: {
+            type: 'number',
+          },
+        },
+        image_quality_score: {
+          type: 'number',
+        },
       },
     },
   },

--- a/src/poi/test-utils/messages/PersonDetectionMessageGenerator.ts
+++ b/src/poi/test-utils/messages/PersonDetectionMessageGenerator.ts
@@ -177,7 +177,10 @@ export function generateSinglePersonUpdateData(options: PersonOptions): Object {
       gender: options.gender || 'male',
     },
     recognition: options.name ? { name: options.name } : undefined,
-    best_face_embedding: undefined,
+    best_face_embedding: {
+      face_embeddings: [],
+      image_quality_score: 0,
+    },
   };
 
   if (options.generateEmbeddings) {
@@ -189,7 +192,8 @@ export function generateSinglePersonUpdateData(options: PersonOptions): Object {
       embeddings.push(Math.floor(Math.random() * maxEmbeddingValue + 1));
     }
 
-    data.best_face_embedding = embeddings;
+    data.best_face_embedding.face_embeddings = embeddings;
+    data.best_face_embedding.image_quality_score = 0.999;
   }
   return data;
 }


### PR DESCRIPTION
The person_update schema was incorrect regarding the face embeddings. The array of value is nested in the `best_face_embedding` object that also contains a `image_quality_score` key. This PR fixes that and updates the tests and the `PersonDetectionMessageGenerator` accordingly.