### PR TITLE
Fix/snapshot clone person reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/messages/person-detection/PersonDetectionMessage.ts
+++ b/src/messages/person-detection/PersonDetectionMessage.ts
@@ -21,6 +21,8 @@ export class PersonDetectionMessage extends Message {
   public poi: number;
   public faceEmbeddings: any;
 
+  private json: Object;
+
   /**
    * Parses a PersonDetectionMessage
    *
@@ -45,6 +47,17 @@ export class PersonDetectionMessage extends Message {
     if (json.data.best_face_embedding) {
       this.faceEmbeddings = json.data.best_face_embedding.face_embeddings;
     }
+
+    this.json = json;
+  }
+
+  /**
+   * Creates a PersonDetectionMessage with the same properties
+   * @return {PersonDetectionMessage}
+   */
+  public clone(): PersonDetectionMessage {
+    const message = new PersonDetectionMessage({ ...this.json });
+    return message;
   }
 
   /**

--- a/src/messages/skeleton/SkeletonMessage.ts
+++ b/src/messages/skeleton/SkeletonMessage.ts
@@ -7,6 +7,7 @@ import { Skeleton } from '../../model/skeleton/Skeleton';
  * Encapsulates a Binary message
  */
 export class SkeletonMessage extends Message {
+  public localTimestamp: number = Date.now();
   public data: Uint8Array;
   public personsCount: number;
   public personLength: number;

--- a/src/model/skeleton/Skeleton.ts
+++ b/src/model/skeleton/Skeleton.ts
@@ -52,8 +52,9 @@ export class Skeleton {
   /**
    * Instantiate a Skeleton from a data provider
    * @param {SkeletonBinaryDataProvider} dataProvider
+   * @param {number} localTimestamp
    */
-  constructor(private dataProvider: SkeletonBinaryDataProvider) {}
+  constructor(private dataProvider: SkeletonBinaryDataProvider, public localTimestamp: number) {}
 
   /**
    * Position of the right hand
@@ -292,6 +293,14 @@ export class Skeleton {
    */
   public getDataProvider(): SkeletonBinaryDataProvider {
     return this.dataProvider;
+  }
+
+  /**
+   * Create a Skeleton instance with the same properties
+   * @return {Skeleton} [description]
+   */
+  public clone(): Skeleton {
+    return new Skeleton(this.dataProvider, this.localTimestamp);
   }
 }
 

--- a/src/poi/POIMonitor.spec.ts
+++ b/src/poi/POIMonitor.spec.ts
@@ -69,7 +69,8 @@ test.cb(
       t.is(lastSnapshot.getPersons().get(personId).ttid, ttid);
       t.is(poiMonitor['isActive'], true);
       t.end();
-    }, INACTIVE_STREAM_THRESHOLD + n * INACTIVE_STREAM_MESSAGE_INTERVAL);
+    }, INACTIVE_STREAM_THRESHOLD + (n + 1) * INACTIVE_STREAM_MESSAGE_INTERVAL);
+    // n + 1 because the first emission starts after 200ms (setInterval)
   }
 );
 
@@ -99,7 +100,7 @@ test.cb(
       emittedSnapshots.push(snapshot);
     });
 
-    // Emit a person detection every 10ms
+    // Emit a person detection every 100ms
     const personId = 'rcyb48vg-4eha';
     const ttid = 89;
     const detectionsInterval = setInterval(() => {
@@ -111,7 +112,7 @@ test.cb(
         data: new Uint8Array([0, 1, ...generateSinglePersonBinaryData({ ttid })]),
         type: BinaryType.SKELETON,
       });
-    }, 10);
+    }, 100);
 
     poiMonitor.start();
 

--- a/src/poi/POISnapshot.spec.ts
+++ b/src/poi/POISnapshot.spec.ts
@@ -57,7 +57,7 @@ test('should add the person to the snapshot when both json and binary data are r
 test(`
 Scenario:
   - Add person 1,
-  - Adds person 2
+  - Add person 2
   - 20 secs later receive an update from person 2 only
   - Receive a persons_alive message containing only [2]
 
@@ -103,8 +103,7 @@ Expected: should have person 2 only in the snapshot
   snapshot.update(json2Update);
   snapshot.update(binary2Update);
 
-  // person 1 does not
-
+  // person 1 does not get updated
   const personsAlive = PersonsAliveMessageGenerator.generate([personId2], timestamp);
   snapshot.update(personsAlive);
 
@@ -116,7 +115,7 @@ Expected: should have person 2 only in the snapshot
 test(`
 Scenario:
   - Add person 1,
-  - Adds person 2
+  - Add person 2
   - 20 secs later receive an update from person 1 and person 2
   - Receive a persons_alive message containing only [2]
 

--- a/src/poi/POISnapshot.ts
+++ b/src/poi/POISnapshot.ts
@@ -153,11 +153,13 @@ export class POISnapshot {
   public clone(): POISnapshot {
     const snapshot = new POISnapshot();
     snapshot.persons = new Map();
+    snapshot.personsByTtid = new Map();
     this.persons.forEach((person, personId) => {
-      snapshot.persons.set(personId, person.clone());
+      const clonedPerson = person.clone();
+      snapshot.persons.set(personId, clonedPerson);
+      snapshot.personsByTtid.set(person.ttid, clonedPerson);
     });
     snapshot.lastPersonUpdate = new Map(this.lastPersonUpdate);
-    snapshot.personsByTtid = new Map(this.personsByTtid);
     snapshot.personsCache = new Map(this.personsCache);
     snapshot.content = this.content ? this.content.clone() : undefined;
     snapshot.contentEvent = this.contentEvent;
@@ -210,7 +212,7 @@ export class POISnapshot {
         obj.binary.personAttributes.male !== undefined
       ) {
         this.persons.set(obj.json.personId, person);
-        this.personsByTtid.set(obj.binary.personAttributes.ttid, person);
+        this.personsByTtid.set(ttid, person);
       }
 
       this.lastPersonUpdate.set(person.personId, person.localTimestamp);

--- a/src/poi/POISnapshot.ts
+++ b/src/poi/POISnapshot.ts
@@ -77,7 +77,10 @@ export class POISnapshot {
         const json = p['json'];
         const personAttributes = p['personAttributes'];
         const binary = {
-          skeleton: new Skeleton(new SkeletonBinaryDataProvider(p['dataProvider'])),
+          skeleton: new Skeleton(
+            new SkeletonBinaryDataProvider(p['dataProvider']),
+            json['localTimestamp']
+          ),
           personAttributes,
         };
         const person = PersonDetection.fromMessage(json, binary);
@@ -133,7 +136,10 @@ export class POISnapshot {
     if (message instanceof SkeletonMessage) {
       let start = 2;
       for (let i = 0; i < message.personsCount; ++i) {
-        this.updateSkeleton(message.data.subarray(start, start + message.personLength));
+        this.updateSkeleton(
+          message.data.subarray(start, start + message.personLength),
+          message.localTimestamp
+        );
         start += message.personLength;
       }
     } else if (message instanceof PersonDetectionMessage) {
@@ -226,14 +232,16 @@ export class POISnapshot {
   /**
    * Updates data about a skeleton
    * @param {Uint8Array} data the message containing the update
+   * @param {number} localTimestamp of the message
    */
-  private updateSkeleton(data: Uint8Array): void {
+  private updateSkeleton(data: Uint8Array, localTimestamp: number): void {
     const personAttributes = new PersonAttributes(data.subarray(Skeleton.bytesLength()));
     const ttid = personAttributes.ttid;
     try {
       const binary: BinaryCachedData = {
         skeleton: new Skeleton(
-          new SkeletonBinaryDataProvider(data.subarray(0, Skeleton.bytesLength()))
+          new SkeletonBinaryDataProvider(data.subarray(0, Skeleton.bytesLength())),
+          localTimestamp
         ),
         personAttributes: personAttributes,
       };
@@ -246,6 +254,8 @@ export class POISnapshot {
         binary.personAttributes.male !== undefined
       ) {
         person.updateFromBinary(binary);
+        this.lastPersonUpdate.set(person.personId, person.localTimestamp);
+        this.lastUpdateTimestamp = person.localTimestamp;
       }
     } catch (e) {
       console.warn(e.message);
@@ -312,7 +322,6 @@ export class POISnapshot {
   private removeGonePersons(timestamp: number) {
     for (const pid of this.lastPersonUpdate.keys()) {
       const lastUpdate = this.lastPersonUpdate.get(pid);
-
       if (timestamp - lastUpdate > MAX_RECENT_TIME) {
         this.persons.delete(pid);
         this.lastPersonUpdate.delete(pid);

--- a/src/poi/test-utils/messages/SkeletonMessageGenerator.ts
+++ b/src/poi/test-utils/messages/SkeletonMessageGenerator.ts
@@ -23,7 +23,9 @@ export class SkeletonMessageGenerator {
     );
 
     const binaryMessageEvent = { type: BinaryType.SKELETON, data: new Uint8Array(data) };
-    return MessageFactory.parse(binaryMessageEvent) as SkeletonMessage;
+    const message = MessageFactory.parse(binaryMessageEvent) as SkeletonMessage;
+    message.localTimestamp = Math.max(...options.map(option => option.localTimestamp));
+    return message;
   }
 }
 

--- a/src/poi/test-utils/model/PersonDetectionGenerator.ts
+++ b/src/poi/test-utils/model/PersonDetectionGenerator.ts
@@ -21,7 +21,8 @@ export class PersonDetectionGenerator {
     const personAttributes = new PersonAttributes(data.subarray(Skeleton.bytesLength()));
     const binary = {
       skeleton: new Skeleton(
-        new SkeletonBinaryDataProvider(data.subarray(0, Skeleton.bytesLength()))
+        new SkeletonBinaryDataProvider(data.subarray(0, Skeleton.bytesLength())),
+        options.localTimestamp
       ),
       personAttributes: personAttributes,
     };


### PR DESCRIPTION
This PR fixes 4 issues

- the 1st commit fixes a reference problem when cloning the POISnapshot, this caused the timestamps to be wrong
- the 2nd commit adds a timestamp to the `SkeletonMessage` when they arrive. After that the `PersonDetection` timestamp will be `Max(jsonTimestamp, binaryTimestamp)`. In the future, TEC will provide this timestamp in the binary data and we won't have to do this timestamping on our side.
- the last commit fixes the wrong order of the `POISnapshot` update and cloning. Instead of updating the last `POISnapshot` and then cloning it and emitting it. We first clone it and then update it. This fix another reference issue where we updated the last `POISnapshot`