### PR TITLE
Remove poi id from PersonDetection model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/messages/person-detection/PersonDetectionMessage.ts
+++ b/src/messages/person-detection/PersonDetectionMessage.ts
@@ -43,7 +43,6 @@ export class PersonDetectionMessage extends Message {
     this.localTimestamp = json.data.local_timestamp;
     this.lookingAtScreen = json.data.behavior.head.looking_at_screen;
     this.cameraId = json.data.camera_id;
-    this.poi = json.data.poi;
     if (json.data.best_face_embedding) {
       this.faceEmbeddings = json.data.best_face_embedding.face_embeddings;
     }

--- a/src/messages/person-detection/PersonDetectionSchema.ts
+++ b/src/messages/person-detection/PersonDetectionSchema.ts
@@ -9,10 +9,6 @@ export const PersonDetectionSchema = {
       description: 'Identifier the type of the record. Never changes for one specific record type.',
       enum: ['person'],
     },
-    poi: {
-      type: 'integer',
-      description: 'PoI ID',
-    },
     local_timestamp: {
       type: 'number',
       description: 'Timestamp in unix epoch format',

--- a/src/model/person-detection/PersonDetection.ts
+++ b/src/model/person-detection/PersonDetection.ts
@@ -39,14 +39,6 @@ export class PersonDetection {
   }
 
   /**
-   * Id of the PoI
-   * @return {number}
-   */
-  get poi(): number {
-    return this.json.poi;
-  }
-
-  /**
    * Distance between the person and the camera
    * @return {number}
    */
@@ -337,7 +329,6 @@ export class PersonDetection {
   public toJSON(): Object {
     return {
       localTimestamp: this.localTimestamp,
-      poi: this.poi,
       name: this.name,
       gender: this.gender,
       personId: this.personId,

--- a/src/poi/test-utils/common.ts
+++ b/src/poi/test-utils/common.ts
@@ -24,7 +24,6 @@ export interface PersonOptions {
   z?: number;
   u?: number;
   v?: number;
-  poi?: number;
   generateEmbeddings?: boolean;
 }
 

--- a/src/poi/test-utils/messages/PersonDetectionMessageGenerator.ts
+++ b/src/poi/test-utils/messages/PersonDetectionMessageGenerator.ts
@@ -170,7 +170,6 @@ export function generateSinglePersonUpdateData(options: PersonOptions): Object {
       gender: options.gender,
     },
     local_timestamp: options.localTimestamp || Date.now(),
-    poi: options.poi,
     record_type: 'person',
     rolling_expected_values: {
       age: options.age || 0,


### PR DESCRIPTION
The schema was incorrect and we don't receive the `poi` as part of the `person_update` message. This is a breaking change so the bump is 6.0.0