### PR TITLE
Fix/error on clone decoded snapshot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",
@@ -79,7 +79,7 @@
       "source-map-support/register"
     ],
     "files": [
-      "**/*.spec.ts"
+      "**/*spec.ts"
     ]
   },
   "nyc": {

--- a/src/poi/POISnapshot.spec.ts
+++ b/src/poi/POISnapshot.spec.ts
@@ -301,10 +301,9 @@ test('should encode and decode the snapshot properly', t => {
 
   const expectedPersons = expected.getPersons();
   result.getPersons().forEach((person: PersonDetection) => {
-    // These 2 private arguments of the PersonDetection model are not parsed when
+    // This private argument 'personAttributes' of the PersonDetection model os not parsed when
     // decoding the data. For testing purpose, we copy the value
-    // so that the "deepEqual" comparison does not fail because of them
-    expectedPersons.get(person.personId)['json'] = person['json'];
+    // so that the "deepEqual" comparison does not fail because of it
     expectedPersons.get(person.personId)['personAttributes'] = person['personAttributes'];
   });
 

--- a/src/poi/POISnapshot.spec.ts
+++ b/src/poi/POISnapshot.spec.ts
@@ -316,3 +316,38 @@ test('should encode and decode the snapshot properly', t => {
 
   t.deepEqual(expected, result);
 });
+
+test('should decode and clone a snapshot', t => {
+  const expected = POISnapshotGenerator.generate([
+    {
+      localTimestamp: 1537362300000,
+      contentId: '1',
+      contentPlayId: '33e17c5c-214f',
+      name: 'start',
+      personPutIds: [],
+      poi: 1,
+    },
+    {
+      localTimestamp: 1537362330000,
+      ttid: 1,
+      personId: 'sywx4b4d-9sii-f6h8-xxxxxxxxxxx',
+      personPutId: 'rcyb48vg-4eha-sup3-xxxxxxxxxxx',
+      age: 21,
+      gender: 'male',
+      cameraId: 'Camera: ZED',
+      poi: 1,
+    },
+  ]);
+  let result = POISnapshot.decode(encode(expected.toJSON()));
+  result = result.clone();
+
+  const expectedPersons = expected.getPersons();
+  result.getPersons().forEach((person: PersonDetection) => {
+    expectedPersons.get(person.personId)['personAttributes'] = person['personAttributes'];
+  });
+
+  expected['lastPersonUpdate'] = result['lastPersonUpdate'];
+  expected['personsByTtid'] = result['personsByTtid'];
+
+  t.deepEqual(expected, result);
+});

--- a/src/poi/POISnapshot.ts
+++ b/src/poi/POISnapshot.ts
@@ -72,9 +72,9 @@ export class POISnapshot {
 
       // Recreate the PersonDetections
       const entries = Object.entries(jsonSnapshot.persons).map(([id, p]) => {
-        // Since json and personAttributes are PersonDetection private arguments
-        // we don't recreate the instances
-        const json = p['json'];
+        const json = new PersonDetectionMessage(p['json'].json);
+        // Since personAttributes is a PersonDetection private arguments
+        // we don't recreate the instance
         const personAttributes = p['personAttributes'];
         const binary = {
           skeleton: new Skeleton(

--- a/src/poi/test-utils/messages/PersonDetectionMessageGenerator.ts
+++ b/src/poi/test-utils/messages/PersonDetectionMessageGenerator.ts
@@ -175,12 +175,15 @@ export function generateSinglePersonUpdateData(options: PersonOptions): Object {
       age: options.age || 0,
       gender: options.gender || 'male',
     },
-    recognition: options.name ? { name: options.name } : undefined,
     best_face_embedding: {
       face_embeddings: [],
       image_quality_score: 0,
     },
   };
+
+  if (options.name) {
+    data['recognition'] = { name: options.name };
+  }
 
   if (options.generateEmbeddings) {
     const embeddings: Array<number> = [];


### PR DESCRIPTION
Found the following bug:
If you decode a `POISnapshot` from binary data and then do `.clone()`, you'd get the error `json.clone` is not a function.

The reason is, when decoding the `POISnapshot` we don't parse the `json: PersonDetectionMessage` property of the snapshot. Since the `clone` method of POISnapshot [calls `person.json.clone()`](https://github.com/advertima/io/blob/development/src/model/person-detection/PersonDetection.ts#L319), it throws an error.

This PR fixes that. The bug is actually also on 0.5.x but since they are minor versions, I only fix it on 0.6.x.