### PR TITLE
Fix/filtering in binary stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/generated/typedoc
 docs/generated/*.png
 node_modules
 .rpt2_cache
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/incoming-message/TecSDKService.ts
+++ b/src/incoming-message/TecSDKService.ts
@@ -38,7 +38,7 @@ export class TecSDKService implements IncomingMessageService {
    */
   public binaryStreamMessages(type?: BinaryType): Observable<BinaryMessageEvent> {
     return this.connection.binaryStreamMessages.pipe(
-      filter((e: BinaryMessageEvent) => !type || type === e.type)
+      filter((e: BinaryMessageEvent) => type === undefined || type === e.type)
     );
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,9 @@
 export enum BinaryType {
-  IMAGE,
-  SKELETON,
-  THUMBNAIL,
-  HEATMAP,
-  DEPTHMAP,
+  IMAGE = 1,
+  SKELETON = 2,
+  THUMBNAIL = 3,
+  HEATMAP = 4,
+  DEPTHMAP = 5,
 }
 
 export interface BinaryMessageEvent {


### PR DESCRIPTION
The problem was next, when we send 0(binary type of the image) to the `binaryStreamMessages(type: BinaryType) `, binary stream didn't filter by this type and return into the `imageStreamMessages` any stream which received. Because of this, even when we are not expecting to see the image binary stream, we will see it, but with the wrong data.