### PR TITLE
Clear old entries in internal personCache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/poi/POISnapshot.ts
+++ b/src/poi/POISnapshot.ts
@@ -327,6 +327,14 @@ export class POISnapshot {
         this.lastPersonUpdate.delete(pid);
       }
     }
+    for (const [ttid, cache] of this.personsCache.entries()) {
+      const lastUpdate = cache.json
+        ? cache.json.localTimestamp
+        : cache.binary.skeleton.localTimestamp;
+      if (timestamp - lastUpdate > MAX_RECENT_TIME) {
+        this.personsCache.delete(ttid);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
This cache should generally not cause any problem but in case the service only receive the json data (or only receive binary data) of a person, this data would remain in the cache. 

This small improvement remove the old entries from this internal cache.