### PR TITLE
Fix/content event generator default data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/poi/POISnapshot.spec.ts
+++ b/src/poi/POISnapshot.spec.ts
@@ -298,6 +298,18 @@ test('should encode and decode the snapshot properly', t => {
       personPutIds: [],
       poi: 1,
     },
+    {
+      localTimestamp: 1537362330000,
+      contentId: '1',
+      contentPlayId: '33e17c5c-214f',
+      name: 'ikea_playout_start',
+      data: {
+        name: 'game_start',
+        hello: 'world',
+      },
+      personPutIds: [],
+      poi: 1,
+    },
   ]);
   const result = POISnapshot.decode(encode(expected.toJSON()));
 
@@ -336,6 +348,18 @@ test('should decode and clone a snapshot', t => {
       age: 21,
       gender: 'male',
       cameraId: 'Camera: ZED',
+      poi: 1,
+    },
+    {
+      localTimestamp: 1537362330000,
+      contentId: '1',
+      contentPlayId: '33e17c5c-214f',
+      name: 'ikea_playout_start',
+      data: {
+        name: 'game_start',
+        hello: 'world',
+      },
+      personPutIds: [],
       poi: 1,
     },
   ]);

--- a/src/poi/test-utils/messages/ContentMessageGenerator.ts
+++ b/src/poi/test-utils/messages/ContentMessageGenerator.ts
@@ -19,7 +19,7 @@ export class ContentMessageGenerator {
         record_type: RPCRecordType.ContentEvent,
         local_timestamp: options.localTimestamp || Date.now(),
         name: options.name || '',
-        data: options.data || {},
+        data: options.data,
         content_id: options.contentId,
         content_play_id: options.contentPlayId,
         person_put_ids: options.personPutIds || [],


### PR DESCRIPTION
Minor changes:

- Removed the default value for the test messages created with the `ContentMessageGenerator`

- Added a custom content event in the POISnapshot input data for 2 tests: the tests were failing because after encoding and decoding a POISnapshot, `contentEventData: undefined` was transformed to `contentEventData: null`