### PR TITLE
Fix/code improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3107,7 +3107,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3131,13 +3132,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3154,19 +3157,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3297,7 +3303,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3311,6 +3318,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3327,6 +3335,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3335,13 +3344,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3362,6 +3373,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3450,7 +3462,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3464,6 +3477,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3559,7 +3573,8 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3601,6 +3616,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3622,6 +3638,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3670,13 +3687,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5521,6 +5540,7 @@
           "resolved": false,
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -5890,7 +5910,8 @@
           "version": "1.1.6",
           "resolved": false,
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -5986,6 +6007,7 @@
           "resolved": false,
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -6038,7 +6060,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -6341,7 +6364,8 @@
           "version": "1.6.1",
           "resolved": false,
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -54,14 +54,6 @@ export class IO {
    * @param {PlayoutEvent} event
    */
   public reportPlayoutEvent(event: PlayoutEvent): void {
-    const personList = Array.from(
-      this.poiMonitor
-        .getPOISnapshot()
-        .getPersons()
-        .values()
-    );
-    event.persons = personList.map(p => p.personPutId);
-
     this.poiMonitor.emitMessage(
       MessageFactory.parse({
         data: {
@@ -71,7 +63,6 @@ export class IO {
           poi: event.poi,
           local_timestamp: event.localTimestamp,
           content_play_id: event.contentPlayId,
-          person_put_ids: event.persons,
           data: event.data,
         },
       })

--- a/src/messages/content/ContentMessage.ts
+++ b/src/messages/content/ContentMessage.ts
@@ -12,7 +12,6 @@ export class ContentMessage extends Message {
   public name: string;
   public contentId: string;
   public contentPlayId: string;
-  public personPutIds: Array<string>;
   public data: Object;
 
   /**
@@ -27,7 +26,6 @@ export class ContentMessage extends Message {
     this.name = json['data']['name'];
     this.contentId = json['data']['content_id'];
     this.contentPlayId = json['data']['content_play_id'];
-    this.personPutIds = json['data']['person_put_ids'];
     this.data = json['data']['data'];
   }
 

--- a/src/messages/content/ContentSchema.ts
+++ b/src/messages/content/ContentSchema.ts
@@ -30,23 +30,9 @@ export const ContentSchema = {
     content_play_id: {
       type: 'string',
     },
-    person_put_ids: {
-      type: 'array',
-      items: {
-        type: 'string',
-      },
-    },
     data: {
       type: 'object',
     },
   },
-  required: [
-    'record_type',
-    'poi',
-    'local_timestamp',
-    'name',
-    'content_id',
-    'content_play_id',
-    'person_put_ids',
-  ],
+  required: ['record_type', 'poi', 'local_timestamp', 'name', 'content_id', 'content_play_id'],
 };

--- a/src/model/content/Content.ts
+++ b/src/model/content/Content.ts
@@ -25,7 +25,6 @@ export class Content {
     content.event = message.name;
     content.contentId = message.contentId;
     content.contentPlayId = message.contentPlayId;
-    content.personPutIds = message.personPutIds;
     content.data = message.data;
 
     return content;
@@ -43,7 +42,6 @@ export class Content {
     content.event = this.event;
     content.contentId = this.contentId;
     content.contentPlayId = this.contentPlayId;
-    content.personPutIds = this.personPutIds;
     content.data = this.data;
     return content;
   }

--- a/src/model/playout-event/PlayoutEvent.ts
+++ b/src/model/playout-event/PlayoutEvent.ts
@@ -19,7 +19,6 @@ export class PlayoutEvent {
     public contentId: string,
     public contentPlayId: string,
     public poi: number,
-    public persons: string[],
     public localTimestamp: number,
     public data: Object = {}
   ) {}
@@ -36,7 +35,7 @@ export class StartEvent extends PlayoutEvent {
    * @param {number} localTimestamp
    */
   constructor(contentId: string, contentPlayId: string, poi: number, localTimestamp: number) {
-    super(StartEventKey, contentId, contentPlayId, poi, [], localTimestamp);
+    super(StartEventKey, contentId, contentPlayId, poi, localTimestamp);
   }
 }
 
@@ -51,7 +50,7 @@ export class EndEvent extends PlayoutEvent {
    * @param {number} localTimestamp
    */
   constructor(contentId: string, contentPlayId: string, poi: number, localTimestamp: number) {
-    super(EndEventKey, contentId, contentPlayId, poi, [], localTimestamp);
+    super(EndEventKey, contentId, contentPlayId, poi, localTimestamp);
   }
 }
 
@@ -81,6 +80,6 @@ export class CustomEvent extends PlayoutEvent {
  Use StartEvent or EndEvent instead`
       );
     }
-    super(name, contentId, contentPlayId, poi, [], localTimestamp, data);
+    super(name, contentId, contentPlayId, poi, localTimestamp, data);
   }
 }

--- a/src/poi/POIMonitor.ts
+++ b/src/poi/POIMonitor.ts
@@ -116,7 +116,7 @@ export class POIMonitor {
       this.isActive = false;
       this.logger.warn('PoI stopped emitting.');
       this.mockMessagesInterval = setInterval(() => {
-        this.lastPOISnapshot.setPersons(new Map());
+        this.lastPOISnapshot.clearPersons();
         this.lastPOISnapshot.update(new PersonsAliveMessage({ data: { person_ids: [] } }));
         const clonedPOISnapshot = this.lastPOISnapshot.clone();
         this.snapshots.next(clonedPOISnapshot);

--- a/src/poi/POISnapshot.ts
+++ b/src/poi/POISnapshot.ts
@@ -49,6 +49,16 @@ export class POISnapshot {
   }
 
   /**
+   * Clears the persons from the memory
+   * (also the internal cached maps)
+   */
+  public clearPersons(): void {
+    this.persons.clear();
+    this.personsByTtid.clear();
+    this.personsCache.clear();
+  }
+
+  /**
    * Creates a POISnapshot from encoded data
    * @param {Uint8Array} data encoded binary data
    * @return {POISnapshot} decoded POI snapshot

--- a/src/poi/test-utils/messages/ContentMessageGenerator.ts
+++ b/src/poi/test-utils/messages/ContentMessageGenerator.ts
@@ -22,7 +22,6 @@ export class ContentMessageGenerator {
         data: options.data,
         content_id: options.contentId,
         content_play_id: options.contentPlayId,
-        person_put_ids: options.personPutIds || [],
       },
     }) as ContentMessage;
   }


### PR DESCRIPTION

- Clear the persons + internal persons cache when the POI stops emitting. This [commit](https://github.com/advertima/io/pull/42/commits/dd091e476aeb5f4fceca883a38d42196301b030d) had the accidental consequence of not clearing the internal persons cache when the stream is broken. This caused some of the `Precondition failed errors`
- Remove the person_put_ids list on the ContentMessage (this is unused)
