### PR TITLE
Update binary screen resolutions everytime the stream reconnects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/connection/TecWSConnection.ts
+++ b/src/connection/TecWSConnection.ts
@@ -25,12 +25,32 @@ export class TecWSConnection implements WSConnection {
     BinaryMessageEvent
   >();
   private binaryStreamMessagesObservable: Observable<BinaryMessageEvent>;
+
+  private jsonStreamConnectionOpenedSubject = new Subject<void>();
+  private binaryStreamConnectionOpenedSubject = new Subject<void>();
+
   /**
    * Creates an instance of TecWSConnection
    */
   constructor() {
     this.jsonStreamMessagesObservable = this.jsonStreamMessagesSubject.asObservable();
     this.binaryStreamMessagesObservable = this.binaryStreamMessagesSubject.asObservable();
+  }
+
+  /**
+   * Emits a message when the json stream connection is (re)opened
+   * @return {Observable<void>}
+   */
+  get jsonStreamConnectionOpened(): Observable<void> {
+    return this.jsonStreamConnectionOpenedSubject.asObservable();
+  }
+
+  /**
+   * Emits a message when the binary stream connection is (re)opened
+   * @return {Observable<void>}
+   */
+  get binaryStreamConnectionOpened(): Observable<void> {
+    return this.binaryStreamConnectionOpenedSubject.asObservable();
   }
 
   /**
@@ -128,6 +148,7 @@ export class TecWSConnection implements WSConnection {
    */
   private onJsonStreamOpen(): void {
     this.jsonStreamStatus = WSConnectionStatus.Open;
+    this.jsonStreamConnectionOpenedSubject.next();
   }
 
   /**
@@ -150,6 +171,7 @@ export class TecWSConnection implements WSConnection {
    */
   private onBinaryStreamOpen(): void {
     this.binaryStreamStatus = WSConnectionStatus.Open;
+    this.binaryStreamConnectionOpenedSubject.next();
   }
 
   /**

--- a/src/connection/WSConnection.ts
+++ b/src/connection/WSConnection.ts
@@ -15,6 +15,8 @@ export interface WSConnection {
   close(): void;
   sendJsonStream(data: any): void;
   sendBinaryStream(data: any): void;
+  readonly jsonStreamConnectionOpened: Observable<void>;
+  readonly binaryStreamConnectionOpened: Observable<void>;
   readonly jsonStreamMessages: Observable<Object>;
   readonly binaryStreamMessages: Observable<BinaryMessageEvent>;
 }

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -46,6 +46,10 @@ export class IO {
     this.incomingMessageService = new TecSDKService(this.connection);
     this.rpcService = new TecRPCService(this.connection, this.incomingMessageService);
     this.poiMonitor = new POIMonitor(this.incomingMessageService);
+
+    connection.binaryStreamConnectionOpened.subscribe(() => {
+      this.updateResolutions();
+    });
   }
 
   /**
@@ -75,7 +79,6 @@ export class IO {
    */
   public connect(options: IOOptions): void {
     this.connection.open(options);
-    this.updateResolutions();
     if (!options.noSnapshot) {
       this.poiMonitor.start();
     }


### PR DESCRIPTION
@nik-dv found out that when the 8002 (binary) stream connection is lost and reconnected later, we don't send the screen resolutions values again, and consequently the stream does not emit the skeleton data. 

To fix it, the `WSConnection` exposes an Observable that emits when the connection is opened, we can use this event to do any other action required after connection. Here, we call `updateResolutions()` when the observable emits a new value.