### PR TITLE
Dev/pedge 319 resolutions improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/connection/TecWSConnection.ts
+++ b/src/connection/TecWSConnection.ts
@@ -102,6 +102,10 @@ export class TecWSConnection implements WSConnection {
    * @param {any} data to send
    */
   public sendJsonStream(data: any): void {
+    if (this.jsonStreamStatus === WSConnectionStatus.Closed) {
+      console.warn('The JSON stream connection is not opened.');
+      return;
+    }
     this.jsonStream.sendJson(data);
   }
 
@@ -110,6 +114,10 @@ export class TecWSConnection implements WSConnection {
    * @param {any} data to send
    */
   public sendBinaryStream(data: any): void {
+    if (this.binaryStreamStatus === WSConnectionStatus.Closed) {
+      console.warn('The binary stream connection is not opened.');
+      return;
+    }
     this.binaryStream.sendJson(data);
   }
 

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -35,8 +35,8 @@ export class IO {
   private poiMonitor: POIMonitor;
 
   private canvasOptions: BinaryOptions = { width: 1920, height: 1080 };
-  private imageOptions: BinaryOptions = { width: 100, height: 100 };
-  private thumbnailOptions: BinaryOptions = { width: 100, height: 100 };
+  private imageOptions: BinaryOptions = { width: 0, height: 0 };
+  private thumbnailOptions: BinaryOptions = { width: 0, height: 0 };
 
   /**
    * Creates an instance of IO

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -77,7 +77,7 @@ export class IO {
    * Opens a connection and start monitoring the messages
    * @param {IOOptions} options
    */
-  public connect(options: IOOptions): void {
+  public connect(options: IOOptions = {}): void {
     this.connection.open(options);
     if (!options.noSnapshot) {
       this.poiMonitor.start();
@@ -107,8 +107,7 @@ export class IO {
    * @return {Observable<BinaryMessageEvent>}
    */
   public imageStreamMessages(width?: number, height?: number): Observable<BinaryMessageEvent> {
-    this.imageOptions = isNaN(width) || isNaN(height) ? this.imageOptions : { width, height };
-    this.updateResolutions();
+    this.updateResolutions(isNaN(width) || isNaN(height) ? {} : { image: { width, height } });
     return this.incomingMessageService.binaryStreamMessages(BinaryType.IMAGE);
   }
 
@@ -119,8 +118,7 @@ export class IO {
    * @return {Observable<BinaryMessageEvent>}
    */
   public skeletonStreamMessages(width?: number, height?: number): Observable<BinaryMessageEvent> {
-    this.canvasOptions = isNaN(width) || isNaN(height) ? this.canvasOptions : { width, height };
-    this.updateResolutions();
+    this.updateResolutions(isNaN(width) || isNaN(height) ? {} : { canvas: { width, height } });
     return this.incomingMessageService.binaryStreamMessages(BinaryType.SKELETON);
   }
 
@@ -131,9 +129,7 @@ export class IO {
    * @return {Observable<BinaryMessageEvent>}
    */
   public thumbnailStreamMessages(width?: number, height?: number): Observable<BinaryMessageEvent> {
-    this.thumbnailOptions =
-      isNaN(width) || isNaN(height) ? this.thumbnailOptions : { width, height };
-    this.updateResolutions();
+    this.updateResolutions(isNaN(width) || isNaN(height) ? {} : { thumbnail: { width, height } });
     return this.incomingMessageService.binaryStreamMessages(BinaryType.THUMBNAIL);
   }
 
@@ -187,10 +183,19 @@ export class IO {
   public updateResolutions(
     options: { canvas?: BinaryOptions; image?: BinaryOptions; thumbnail?: BinaryOptions } = {}
   ): void {
+    if (options.canvas) {
+      this.canvasOptions = options.canvas;
+    }
+    if (options.image) {
+      this.imageOptions = options.image;
+    }
+    if (options.thumbnail) {
+      this.thumbnailOptions = options.thumbnail;
+    }
     this.connection.sendBinaryStream({
-      canvas: options.canvas || this.canvasOptions,
-      image: options.image || this.imageOptions,
-      thumbnail: options.thumbnail || this.thumbnailOptions,
+      canvas: this.canvasOptions,
+      image: this.imageOptions,
+      thumbnail: this.thumbnailOptions,
     });
   }
 }

--- a/src/model/person-detection/PersonDetection.ts
+++ b/src/model/person-detection/PersonDetection.ts
@@ -11,7 +11,7 @@ export interface RecognitionMetadata {
  * Person Detection model
  */
 export class PersonDetection {
-  private skeleton: Skeleton;
+  private _skeleton: Skeleton;
   private personAttributes: PersonAttributes;
   private faceEmbeddings: Array<number> = [];
   private json: PersonDetectionMessage;
@@ -24,13 +24,13 @@ export class PersonDetection {
    * @return {number}
    */
   get localTimestamp(): number {
-    if (!this.json.localTimestamp && !this.skeleton.localTimestamp) {
+    if (!this.json.localTimestamp && !this._skeleton.localTimestamp) {
       return undefined;
     }
 
     const localTimestamp = Math.max(
       this.json.localTimestamp || 0,
-      this.skeleton.localTimestamp || 0
+      this._skeleton.localTimestamp || 0
     );
 
     if (localTimestamp) {
@@ -113,27 +113,35 @@ export class PersonDetection {
   }
 
   /**
-   * Returing 3d x-coordinate of the persons's body in meters
+   * Returns 3d x-coordinate of the persons's body in meters
    * @return  {number}
    */
   get u(): number {
-    return this.skeleton.neckU;
+    return this._skeleton.neckU;
   }
 
   /**
-   * Returing 3d y-coordinate of the persons's body in meters
+   * Returns 3d y-coordinate of the persons's body in meters
    * @return  {number}
    */
   get v(): number {
-    return this.skeleton.neckV;
+    return this._skeleton.neckV;
   }
 
   /**
-   * Returing 3d z-coordinate of the persons's body
+   * Returns 3d z-coordinate of the persons's body
    * @return  {number}
    */
   get z(): number {
-    return this.skeleton.neckZ;
+    return this._skeleton.neckZ;
+  }
+
+  /**
+   * Returns the skeleton object
+   * @return {Skeleton}
+   */
+  get skeleton(): Skeleton {
+    return this._skeleton;
   }
 
   /**
@@ -287,7 +295,7 @@ export class PersonDetection {
    * @param {BinaryCachedData} binary data
    */
   public updateFromBinary(binary: BinaryCachedData): void {
-    this.skeleton = binary.skeleton;
+    this._skeleton = binary.skeleton;
     this.personAttributes = binary.personAttributes;
   }
 
@@ -301,7 +309,7 @@ export class PersonDetection {
     const person = new PersonDetection();
 
     person.json = json;
-    person.skeleton = cache.skeleton;
+    person._skeleton = cache.skeleton;
     person.personAttributes = cache.personAttributes;
     person.faceEmbeddings = json.faceEmbeddings || [];
 
@@ -318,7 +326,7 @@ export class PersonDetection {
    */
   public clone(): PersonDetection {
     return PersonDetection.fromMessage(this.json.clone(), {
-      skeleton: this.skeleton.clone(),
+      skeleton: this._skeleton.clone(),
       personAttributes: this.personAttributes.clone(),
     });
   }
@@ -353,7 +361,7 @@ export class PersonDetection {
       allFaceAttributes: this.allFaceAttributes,
       json: this.json,
       personAttributes: this.personAttributes,
-      dataProvider: this.skeleton.getDataProvider().getData(),
+      dataProvider: this._skeleton.getDataProvider().getData(),
     };
   }
 }


### PR DESCRIPTION
Some fixes that were required for PEDGE-319

- when the client called `updateResolutions({ thumbnail: {width: 100, height: 100}...)`, the params were not kept in memory. It was only the case when calling `.thumbnailStreamMessages(100, 100)`.

- Disable the camera and thumbnail feed by default
- Provide a `skeleton` getter in the `PersonDetection` model