### PR TITLE
Dev/pedge 333 expose connection status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/connection/TecWSConnection.spec.ts
+++ b/src/connection/TecWSConnection.spec.ts
@@ -333,3 +333,71 @@ test.serial.cb('should emits a message when the json and binary connection are o
 
   c.open();
 });
+
+test.serial.cb('should return the status OPEN if both the json and binary WS are open', t => {
+  const fakeJsonURL = 'ws://localhost:8001';
+  const mockJsonServer = new Server(fakeJsonURL);
+
+  const fakeBinaryURL = 'ws://localhost:8002';
+  const mockBinaryServer = new Server(fakeBinaryURL);
+
+  const c = new TecWSConnection();
+
+  c.open();
+
+  // wait for both connections to open
+  setTimeout(() => {
+    t.is(c.getStatus(), WSConnectionStatus.Open);
+
+    c.close();
+    mockBinaryServer.stop();
+    mockJsonServer.stop();
+    t.end();
+  }, 100);
+});
+
+test.serial.cb('should return the status OPEN if the binary connection is closed', t => {
+  const fakeJsonURL = 'ws://localhost:8001';
+  const mockJsonServer = new Server(fakeJsonURL);
+
+  const c = new TecWSConnection();
+
+  c.open();
+
+  // wait for the JSON connection to open
+  setTimeout(() => {
+    t.is(c.getStatus(), WSConnectionStatus.Closed);
+
+    c.close();
+    mockJsonServer.stop();
+    t.end();
+  }, 100);
+});
+
+test.serial.cb('should return the status OPEN if the json connection is closed', t => {
+  const fakeBinaryURL = 'ws://localhost:8002';
+  const mockBinaryServer = new Server(fakeBinaryURL);
+
+  const c = new TecWSConnection();
+
+  c.open();
+
+  // wait for the binary connection to open
+  setTimeout(() => {
+    t.is(c.getStatus(), WSConnectionStatus.Closed);
+
+    c.close();
+    mockBinaryServer.stop();
+    t.end();
+  }, 100);
+});
+
+test.serial('should return the status OPEN if both connections are closed', t => {
+  const c = new TecWSConnection();
+
+  c.open();
+
+  t.is(c.getStatus(), WSConnectionStatus.Closed);
+
+  c.close();
+});

--- a/src/connection/TecWSConnection.ts
+++ b/src/connection/TecWSConnection.ts
@@ -70,6 +70,23 @@ export class TecWSConnection implements WSConnection {
   }
 
   /**
+   * If the binary and JSON WS are both opened, status is OPEN
+   * otherwise status is Closed
+   * TODO: once the streams are merged into one, return this.streamStatus
+   * @return {WSConnectionStatus} status of the Tec WS connection
+   */
+  public getStatus(): WSConnectionStatus {
+    if (
+      this.binaryStreamStatus === WSConnectionStatus.Open &&
+      this.jsonStreamStatus === WSConnectionStatus.Open
+    ) {
+      return WSConnectionStatus.Open;
+    }
+
+    return WSConnectionStatus.Closed;
+  }
+
+  /**
    * Opens the connection to the Json and Binary streams
    * @param {TecSdkWSConnectionOptions} options
    */

--- a/src/connection/WSConnection.ts
+++ b/src/connection/WSConnection.ts
@@ -15,6 +15,7 @@ export interface WSConnection {
   close(): void;
   sendJsonStream(data: any): void;
   sendBinaryStream(data: any): void;
+  getStatus(): WSConnectionStatus;
   readonly jsonStreamConnectionOpened: Observable<void>;
   readonly binaryStreamConnectionOpened: Observable<void>;
   readonly jsonStreamMessages: Observable<Object>;

--- a/src/constants/Constants.ts
+++ b/src/constants/Constants.ts
@@ -26,3 +26,5 @@ export enum BinaryDataType {
   TYPE_HEATMAP = 4,
   TYPE_DEPTHMAP = 5,
 }
+
+export { WSConnectionStatus } from '../connection/WSConnection';

--- a/src/io/IO.ts
+++ b/src/io/IO.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import { WSConnection } from '../connection/WSConnection';
+import { WSConnection, WSConnectionStatus } from '../connection/WSConnection';
 import { TecWSConnection } from '../connection/TecWSConnection';
 import { IncomingMessageService } from '../incoming-message/IncomingMessageService';
 import { TecSDKService } from '../incoming-message/TecSDKService';
@@ -50,6 +50,14 @@ export class IO {
     connection.binaryStreamConnectionOpened.subscribe(() => {
       this.updateResolutions();
     });
+  }
+
+  /**
+   * Returns the backend connection status
+   * @return {WSConnectionStatus} connection status
+   */
+  public getConnectionStatus(): WSConnectionStatus {
+    return this.connection.getStatus();
   }
 
   /**

--- a/src/poi/test-utils/poi/POISnapshotGenerator.ts
+++ b/src/poi/test-utils/poi/POISnapshotGenerator.ts
@@ -60,19 +60,21 @@ export class POISnapshotGenerator {
 
     personMessages.forEach((personMessage, index) => {
       const p = snapshot.getPersons().get(personMessage.personId);
-      // Hack to set the z value, otherwise the calculation is too complicated
-      Object.defineProperty(p, 'z', {
-        value: personOptions[index].z || 0,
-        configurable: true,
-      });
-      Object.defineProperty(p, 'u', {
-        value: personOptions[index].u || 0,
-        configurable: true,
-      });
-      Object.defineProperty(p, 'v', {
-        value: personOptions[index].v || 0,
-        configurable: true,
-      });
+      if (p) {
+        // Hack to set the z value, otherwise the calculation is too complicated
+        Object.defineProperty(p, 'z', {
+          value: personOptions[index].z || 0,
+          configurable: true,
+        });
+        Object.defineProperty(p, 'u', {
+          value: personOptions[index].u || 0,
+          configurable: true,
+        });
+        Object.defineProperty(p, 'v', {
+          value: personOptions[index].v || 0,
+          configurable: true,
+        });
+      }
     });
 
     return snapshot;


### PR DESCRIPTION
This PR exposes a method `IO.getStatus()` that returns the status (`WSConnectionStatus`) of the WebSocket connection. As explained in the function doc, we can simplify the status once the 2 connections (ports 8001 and 8002) are merged into one. For now, we consider the connection opened, if both are opened, else the connection is closed.