### PR TITLE
Fix/pedge 361 remove timeout person lost

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # io
 
 [![Build Status](https://travis-ci.org/advertima/io.svg?branch=development)](https://travis-ci.org/advertima/io)
+[![npm version](https://badge.fury.io/js/%40advertima%2Fio.svg)](https://badge.fury.io/js/%40advertima%2Fio)
 [![codecov](https://codecov.io/gh/advertima/io/branch/development/graph/badge.svg)](https://codecov.io/gh/advertima/io)
 
 IO Javascript utilities to connect to a POI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/poi/POIMonitor.spec.ts
+++ b/src/poi/POIMonitor.spec.ts
@@ -7,7 +7,7 @@ import {
   INACTIVE_STREAM_THRESHOLD,
   INACTIVE_STREAM_MESSAGE_INTERVAL,
 } from './POIMonitor';
-import { POISnapshot, MAX_RECENT_TIME } from './POISnapshot';
+import { POISnapshot } from './POISnapshot';
 import { generateSinglePersonUpdateData, generateSinglePersonBinaryData } from './test-utils';
 import { RPCResponseSubject } from '../constants/Constants';
 
@@ -137,15 +137,11 @@ test.cb(
       });
 
       // After, the Stream detections are stopped, expect new empty snapshots emissions
-      setTimeout(() => {
-        t.not(emittedSnapshots.length, 0);
-        for (let i = 0; i < newEmittedSnapshots.length; i++) {
-          t.is(newEmittedSnapshots[i].getPersons().size, 0);
-        }
-        t.end();
-        // the timeout needs to be > MAX_RECENT_TIME, to make sure that the lost persons are cleaned
-        // (the lost persons threshold is 2 seconds)
-      }, MAX_RECENT_TIME + 500);
+      t.not(emittedSnapshots.length, 0);
+      for (let i = 0; i < newEmittedSnapshots.length; i++) {
+        t.is(newEmittedSnapshots[i].getPersons().size, 0);
+      }
+      t.end();
     }, INACTIVE_STREAM_THRESHOLD);
   }
 );

--- a/src/poi/POISnapshot.spec.ts
+++ b/src/poi/POISnapshot.spec.ts
@@ -119,7 +119,7 @@ Scenario:
   - 20 secs later receive an update from person 1 and person 2
   - Receive a persons_alive message containing only [2]
 
-Expected: should still have person 1 and person 2 in the snapshot
+Expected: should remove person 1 from the snapshot
 `, t => {
   const snapshot = new POISnapshot();
   const ttid1 = 23;
@@ -173,9 +173,9 @@ Expected: should still have person 1 and person 2 in the snapshot
   const personsAlive = PersonsAliveMessageGenerator.generate([personId2], timestamp);
   snapshot.update(personsAlive);
 
-  t.is(snapshot.getPersons().size, 2);
+  t.is(snapshot.getPersons().size, 1);
   t.not(snapshot.getPersons().get(personId2), undefined);
-  t.not(snapshot.getPersons().get(personId1), undefined);
+  t.is(snapshot.getPersons().get(personId1), undefined);
 });
 
 test('should have the content', t => {
@@ -321,10 +321,9 @@ test('should encode and decode the snapshot properly', t => {
     expectedPersons.get(person.personId)['personAttributes'] = person['personAttributes'];
   });
 
-  // These 2 internal properties are lost during the encoding
-  // We only add them here for testing purpose,
-  // so that the "deepEqual" comparison does not fail because of them
-  expected['lastPersonUpdate'] = result['lastPersonUpdate'];
+  // This internal property is lost during the encoding
+  // We only add it here for testing purpose,
+  // so that the "deepEqual" comparison does not fail because of it
   expected['personsByTtid'] = result['personsByTtid'];
 
   t.deepEqual(expected, result);
@@ -371,7 +370,6 @@ test('should decode and clone a snapshot', t => {
     expectedPersons.get(person.personId)['personAttributes'] = person['personAttributes'];
   });
 
-  expected['lastPersonUpdate'] = result['lastPersonUpdate'];
   expected['personsByTtid'] = result['personsByTtid'];
 
   t.deepEqual(expected, result);


### PR DESCRIPTION
The previous cleanup behaviour was happening when we receive a `PersonsAliveMessage`, we were removing from the `POISnapshot` the person detections older than 2 seconds. After discussion with @SimonEbner, we agreed that we should immediately remove the persons that are not in the `PersonsAliveMessage` list.

This PR does this fix and makes the related changes in the test utils.

I've also added the npm badge to the home page.