### PR TITLE
Fix/lodash import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
 language: node_js
 node_js:
-  - 'lts/carbon'
+- lts/carbon
 script:
-  - npm run checkstyle
-  - npm test
-  - npm run test:report
+- npm run checkstyle
+- npm test
+- npm run test:report
+deploy:
+  provider: npm
+  email: micael.mbagira@icloud.com
+  api_key:
+    secure: ZpbQ3rY1h3F+meeD1765A6zIT3FopzSQG97pZlqrqIBm7TdXsOyLO2T8S7PV6OgSRAZBpjiSl7V2pwZbHbIGiBPcUGz80MV5RJzOl5R26qYOuSTMp4uiUmtVnks7o+5g9iNeQRZ9yH3q5SLRVZ/Vzjlgp3J1hKiEP5W0qhqtFfh5H0vmdt25Rid+ybRNtrOw3L9gcRnxe3rd703l84gJ27+fAgigZT5zFCLqEDoPEt8LyjoWeVIbe6aWnkHOKXaPUBkRb3QEjz6D3j3XoR5tiAmF0KzloZMpez6Ux+6yqIYUIUsp1gbRN0GbZlh4BfkQ6I4IQ935BHK74jp66oPq6qekKv3Rdyx8pCKasybdHErIItaXF8Vt+E+ZhrLhD5KU2S70uD4dM1AuiLM05JvpcL0y4weumI1BzqEDcJM0GV3DXb1RjrSro0cECobCVi4NU4MxqZo1iit2G0Us544ENtcSk5Lu7HxfTJkx3uc8VkngsZFlGCAFxKYCl3KCUkaiRZ4UYWuUI2kmabJi50MMb5ntIpBWrRAk0GZ4aqgEFU/3EUh8Rh1iVSVaya2mYu/XijYYe/NwFLQJEuyxcVYRQyc910eV1kV31d2juxKBvSk4OEqnfPoB3Eiy+FsaZ6rgkDSDZdpbhEdKs19ZPz1RNkh41aCYXh1rS2Q7U6gAmFU=
+  on:
+    tags: true
+    repo: advertima/io
+    branch: development

--- a/package-lock.json
+++ b/package-lock.json
@@ -510,10 +510,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.104",
-      "resolved": "http://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz",
-      "integrity": "sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ==",
-      "dev": true
+      "version": "4.14.123",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
+      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q=="
     },
     "@types/marked": {
       "version": "0.3.0",
@@ -9100,6 +9099,12 @@
         "typescript": "2.7.2"
       },
       "dependencies": {
+        "@types/lodash": {
+          "version": "4.14.104",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz",
+          "integrity": "sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "browser": "lib/io.umd.js",
   "types": "lib/index.d.ts",
   "files": [
-    "lib",
-    "src"
+    "lib"
   ],
   "scripts": {
     "clean": "rimraf lib dist .rpt2_cache",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "homepage": "https://github.com/advertima/io#readme",
   "dependencies": {
+    "@types/lodash": "^4.14.123",
     "isomorphic-ws": "^4.0.1",
     "jsonschema": "^1.2.4",
     "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/messages/person-detection/PersonDetectionMessage.ts
+++ b/src/messages/person-detection/PersonDetectionMessage.ts
@@ -1,5 +1,5 @@
 import { validate } from 'jsonschema';
-import { cloneDeep } from 'lodash';
+const cloneDeep = require('lodash/cloneDeep');
 import { Message } from '../Message';
 import { PersonDetectionSchema } from './PersonDetectionSchema';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "target": "es6",
-    "types": ["node", "ws", "uuid", "sinon"]
+    "types": ["node", "ws", "uuid", "sinon"],
+    "allowSyntheticDefaultImports": true
   },
   "exclude": [
     "dist",


### PR DESCRIPTION
Using `import cloneDeep from 'lodash/cloneDeep'` instead of import {cloneDeep} from 'lodash'` reduces the bundle size (because lodash don't have modules unfortunately).

And because of TypeScript, I had to use `require` because the syntax `from 'lodash/cloneDeep'` is not working....

I also configured Travis to automatically deploy when there is a new tag on `development` (the key is encrypted, no worries ✌️ ) 