### PR TITLE
Fix/pedge 373 update snapshot on skeleton msg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advertima/io",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "IO utilities to connect to a PoI",
   "main": "lib/io.cjs.js",
   "module": "lib/io.esm.js",

--- a/src/messages/person-detection/PersonDetectionMessage.ts
+++ b/src/messages/person-detection/PersonDetectionMessage.ts
@@ -9,7 +9,7 @@ import { PersonDetectionSchema } from './PersonDetectionSchema';
 export class PersonDetectionMessage extends Message {
   public age: number;
   public gender: string;
-  public ttid: string;
+  public ttid: number;
   public personId: string;
   public personPutId: string;
   public coordinates: Object;

--- a/src/poi/POIMonitor.ts
+++ b/src/poi/POIMonitor.ts
@@ -1,5 +1,5 @@
 import { Subject } from 'rxjs';
-import { Observer, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { Subscription, merge } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Message } from '../messages/Message';
@@ -52,7 +52,7 @@ export class POIMonitor {
         this.msgService.binaryStreamMessages(BinaryType.SKELETON)
       )
         .pipe(map(json => MessageFactory.parse(json)))
-        .subscribe(new MessageObserver(this));
+        .subscribe(m => this.emitMessage(m), e => Logger.error(e), () => this.complete());
     }
   }
 
@@ -131,44 +131,5 @@ export class POIMonitor {
    */
   public getPOISnapshotObservable(): Observable<POISnapshot> {
     return this.poiSnapshotObservable;
-  }
-}
-
-/**
- * Listens for incoming messages.
- */
-class MessageObserver implements Observer<Message> {
-  /**
-   * Creates a new instance.
-   *
-   * @param {POIMonitor} poiMonitor the POIMonitor instance
-   * that will be used to handle the changes.
-   */
-  constructor(private poiMonitor: POIMonitor) {}
-
-  /**
-   * Executed when a new message is received.
-   * Will trigger the POISnapshot update.
-   *
-   * @param {Message} m the received message.
-   */
-  public next(m: Message): void {
-    this.poiMonitor.emitMessage(m);
-  }
-
-  /**
-   * Error in the observable.
-   *
-   * @param {any} e the error.
-   */
-  public error(e: any): void {
-    Logger.error(e);
-  }
-
-  /**
-   * The stream is completed.
-   */
-  public complete(): void {
-    this.poiMonitor.complete();
   }
 }


### PR DESCRIPTION
This PR changes the POIMonitor strategy: instead of updating and emitting a POISnapshot on every message, we only do it when a PersonsAlive or Skeleton message is emitted. Otherwise, we buffer the PersonDetection messages and we will process them when a PersonAlive or Skeleton message is emitted. 

The reason is that the json (PersonDetection) message are too frequent (1 per detection) compared to the Skeleton or PersonsAlive message (1 msg containing the informations of all detections).

In the future, the PersonDetections message will be completely removed. This PR already prepare this change.